### PR TITLE
Add --source traj support and update trajectory import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ The library modules can be imported directly:
     # Surface fitting (requires jax: pip install rgpycrumbs[surfaces])
     from rgpycrumbs.surfaces import get_surface_model
     model = get_surface_model("tps")
-    
+
     # Structure analysis (requires ase, scipy: pip install rgpycrumbs[analysis])
     from rgpycrumbs.geom.analysis import analyze_structure
-    
+
     # Spline interpolation (requires scipy: pip install rgpycrumbs[interpolation])
     from rgpycrumbs.interpolation import spline_interp
-    
+
     # Data types (no extra deps)
     from rgpycrumbs.basetypes import nebpath, SaddleMeasure
 
@@ -120,12 +120,12 @@ You can see the list of available command groups:
 
     $ python -m rgpycrumbs.cli --help
     Usage: rgpycrumbs [OPTIONS] COMMAND [ARGS]...
-    
+
       A dispatcher that runs self-contained scripts using 'uv'.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       eon  Dispatches to a script within the 'eon' submodule.
 
@@ -137,13 +137,13 @@ You can see the list of available command groups:
 -   Plotting NEB Paths (`plt-neb`)
 
     This script visualizes the energy profile of Nudged Elastic Band (NEB) calculations over optimization steps.
-    
+
     To see the help text for this specific script:
-    
+
         $ python -m rgpycrumbs eon plt-neb --help
         --> Dispatching to: uv run /path/to/rgpycrumbs/eon/plt_neb.py --help
         Usage: plt_neb.py [OPTIONS]
-        
+
           Plots a series of NEB energy paths from .dat files.
         ...
         Options:
@@ -152,13 +152,13 @@ You can see the list of available command groups:
           --start INTEGER           Starting file index to plot (inclusive).
           --end INTEGER             Ending file index to plot (exclusive).
           --help                    Show this message and exit.
-    
+
     To plot a specific range of `neb_*.dat` files and save the output:
-    
+
         python -m rgpycrumbs eon plt-neb --start 100 --end 150 -o final_path.pdf
-    
+
     To show the plot interactively without saving:
-    
+
         python -m rgpycrumbs eon plt-neb --start 280
 
 -   Splitting CON files (`con-splitter`)
@@ -166,11 +166,11 @@ You can see the list of available command groups:
     This script takes a multi-image trajectory file (e.g., from a finished NEB
     calculation) and splits it into individual frame files, creating an input file
     for a new calculation.
-    
+
     To split a trajectory file:
-    
+
         rgpycrumbs eon con-splitter neb_final_path.con -o initial_images
-    
+
     This will create a directory named `initial_images` containing `ipath_000.con`,
     `ipath_001.con`, etc., along with an `ipath.dat` file listing their paths.
 
@@ -192,10 +192,10 @@ This project uses [`uv`](https://docs.astral.sh/uv/) as the primary development 
 
     # Clone and install in development mode with test dependencies
     uv sync --extra test
-    
+
     # Run the pure tests (no heavy optional deps)
     uv run pytest -m pure
-    
+
     # Run interpolation tests (needs scipy)
     uv run --extra interpolation pytest -m interpolation
 
@@ -229,16 +229,16 @@ automatically (e.g. `1.0.1.dev3+gabcdef`).
 
     # 1. Ensure tests pass
     uv run --extra test pytest -m pure
-    
+
     # 2. Build changelog (uses towncrier fragments in docs/newsfragments/)
     uvx towncrier build --version "v1.0.0"
-    
+
     # 3. Commit the changelog
     git add CHANGELOG.rst && git commit -m "doc: release notes for v1.0.0"
-    
+
     # 4. Tag the release (hatch-vcs derives the version from this tag)
     git tag -a v1.0.0 -m "Version 1.0.0"
-    
+
     # 5. Build and publish
     uv build
     uvx twine upload dist/*
@@ -253,4 +253,3 @@ via:
 
 -   The Zenodo DOI for general use.
 -   The `wailord` paper for ORCA usage
-

--- a/docs/newsfragments/2.added.rst
+++ b/docs/newsfragments/2.added.rst
@@ -1,0 +1,3 @@
+Export Nystrom threshold, default inducing count, and ``nystrom_paths_needed``
+from ``rgpycrumbs.surfaces`` so callers can trim data before expensive
+RMSD/IRA aggregation.

--- a/readme_src.org
+++ b/readme_src.org
@@ -7,6 +7,7 @@
 [[https://raw.githubusercontent.com/HaoZeke/rgpycrumbs/refs/heads/main/branding/logo/pycrumbs_logo.webp]]
 #+begin_export markdown
 [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch)
+[![DOI](https://zenodo.org/badge/795596895.svg)](https://doi.org/10.5281/zenodo.18529798)
 #+end_export
 A *pure-python* computational library and CLI toolkit for chemical physics
 research. ~rgpycrumbs~ provides both importable library modules for
@@ -229,7 +230,7 @@ uvx twine upload dist/*
 :END:
 MIT. However, this is an academic resource, so *please cite* as much as possible
 via:
-- The Zenodo DOI for general use.
+- The [[https://doi.org/10.5281/zenodo.18529798][Zenodo DOI]] for general use.
 - The ~wailord~ paper for ORCA usage
 
 # ** Logo

--- a/rgpycrumbs/eon/plt_neb.py
+++ b/rgpycrumbs/eon/plt_neb.py
@@ -319,6 +319,13 @@ IRA_KMAX_DEFAULT = 1.8
     help="ASE rotation string.",
 )
 @click.option(
+    "--strip-renderer",
+    type=click.Choice(["ase", "xyzrender"]),
+    default="ase",
+    show_default=True,
+    help="Rendering backend for structure images.",
+)
+@click.option(
     "--arrow-head-length",
     type=float,
     default=0.2,
@@ -445,6 +452,7 @@ def main(
     dpi,
     zoom_ratio,
     ase_rotation,
+    strip_renderer,
     arrow_head_length,
     arrow_head_width,
     arrow_tail_width,
@@ -792,6 +800,7 @@ def main(
                 zoom=zoom_ratio,
                 rotation=ase_rotation,
                 theme_color=active_theme.textcolor,
+                renderer=strip_renderer,
             )
 
             # Annotate Main Plot
@@ -924,6 +933,7 @@ def main(
                         rad,
                         zoom=zoom_ratio,
                         rotation=ase_rotation,
+                        renderer=strip_renderer,
                     )
         else:
             # eOn source: multiple .dat files
@@ -1028,6 +1038,7 @@ def main(
                             rad,
                             zoom=zoom_ratio,
                             rotation=ase_rotation,
+                            renderer=strip_renderer,
                         )
 
         # --- Profile Additional Structures ---
@@ -1055,6 +1066,7 @@ def main(
                         rad=draw_saddle[2],
                         zoom=zoom_ratio,
                         rotation=ase_rotation,
+                        renderer=strip_renderer,
                         arrow_props={
                             "arrowstyle": ArrowStyle.Fancy(
                                 head_length=arrow_head_length,

--- a/rgpycrumbs/eon/plt_neb.py
+++ b/rgpycrumbs/eon/plt_neb.py
@@ -51,6 +51,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 from adjustText import adjust_text
+from chemparseplot.parse.chemgp.neb import (
+    load_trajectory,
+    trajectory_to_landscape_df,
+    trajectory_to_profile_dat,
+)
 from chemparseplot.parse.eon.neb import (
     aggregate_neb_landscape_data,
     compute_profile_rmsd,
@@ -136,6 +141,18 @@ IRA_KMAX_DEFAULT = 1.8
     type=click.Path(exists=False, dir_okay=False, path_type=Path),
     default=Path("sp.con"),
     help="Path to explicit saddle point file (eOn sp.con).",
+)
+@click.option(
+    "--source",
+    type=click.Choice(["eon", "traj"]),
+    default="eon",
+    help="Data source: 'eon' for .dat/.con pairs, 'traj' for extxyz trajectory.",
+)
+@click.option(
+    "--input-traj",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Path to extxyz trajectory file (used with --source traj).",
 )
 @click.option(
     "--plot-type",
@@ -366,6 +383,9 @@ def main(
     input_path_pattern,
     con_file,
     additional_con,
+    # --- Data Source ---
+    source,
+    input_traj,
     # --- Plot Behavior ---
     plot_type,
     landscape_mode,
@@ -480,38 +500,53 @@ def main(
                 log.critical("Cannot proceed without structures. Exiting.")
                 sys.exit(1)
 
+    # --- Trajectory source: load once if applicable ---
+    traj_atoms_list = None
+    if source == "traj":
+        if not input_traj:
+            log.critical("--input-traj is required when --source traj is used.")
+            sys.exit(1)
+        traj_atoms_list = load_trajectory(str(input_traj))
+
     if plot_type == "landscape":
         # --- Landscape Plot ---
-        dat_paths = find_file_paths(input_dat_pattern)
-        con_paths = find_file_paths(str(input_path_pattern))
-
-        if not dat_paths:
-            log.critical(f"No data files found for pattern: {input_dat_pattern}")
-            sys.exit(1)
-
-        # Fallback if no path files found but main file exists
-        if not con_paths and con_file:
-            con_paths = [con_file]
-
-        y_col = 2 if plot_mode == "energy" else 4
         z_label = (
             "Relative Energy (eV)"
             if plot_mode == "energy"
             else r"Lowest Eigenvalue (eV/$\AA^2$)"
         )
 
-        df = aggregate_neb_landscape_data(
-            dat_paths,
-            con_paths,
-            y_col,
-            None,
-            cache_file,
-            force_recompute,
-            ira_kmax,
-            augment_dat=augment_dat,
-            augment_con=augment_con,
-            ref_atoms=atoms_list[0] if atoms_list else None,  # main reactant
-            prod_atoms=atoms_list[-1] if atoms_list else None,  # main product
+        if source == "traj":
+            df = trajectory_to_landscape_df(traj_atoms_list, ira_kmax=ira_kmax)
+            # Use traj structures for con_file features when not provided
+            if atoms_list is None:
+                atoms_list = traj_atoms_list
+        else:
+            dat_paths = find_file_paths(input_dat_pattern)
+            con_paths = find_file_paths(str(input_path_pattern))
+
+            if not dat_paths:
+                log.critical(f"No data files found for pattern: {input_dat_pattern}")
+                sys.exit(1)
+
+            # Fallback if no path files found but main file exists
+            if not con_paths and con_file:
+                con_paths = [con_file]
+
+            y_col = 2 if plot_mode == "energy" else 4
+
+            df = aggregate_neb_landscape_data(
+                dat_paths,
+                con_paths,
+                y_col,
+                None,
+                cache_file,
+                force_recompute,
+                ira_kmax,
+                augment_dat=augment_dat,
+                augment_con=augment_con,
+                ref_atoms=atoms_list[0] if atoms_list else None,  # main reactant
+                prod_atoms=atoms_list[-1] if atoms_list else None,  # main product
         )
 
         # Surface Generation
@@ -752,67 +787,25 @@ def main(
 
     else:
         # --- Profile Plot ---
-        dat_paths = find_file_paths(input_dat_pattern)
-        file_paths_to_plot = dat_paths[start:end]
+        if source == "traj":
+            # Trajectory source: single extxyz file -> one profile
+            data = trajectory_to_profile_dat(traj_atoms_list)
+            if atoms_list is None:
+                atoms_list = traj_atoms_list
 
-        if not file_paths_to_plot:
-            log.error("No files found in range.")
-            sys.exit(1)
-
-        # Optional: Load RMSD for X-axis
-        rmsd_rc = None
-        if rc_mode == "rmsd" and atoms_list:
-            df_rmsd = compute_profile_rmsd(
-                atoms_list, cache_file, force_recompute, ira_kmax
-            )
-            rmsd_rc = df_rmsd["r"].to_numpy()
-
-        # Plot Loop
-        cm = plt.get_cmap(active_theme.cmap_profile)
-        color_divisor = (
-            len(file_paths_to_plot) - 1 if len(file_paths_to_plot) > 1 else 1.0
-        )
-
-        y_col = 2 if plot_mode == "energy" else 4
-
-        for idx, fpath in enumerate(file_paths_to_plot):
-            try:
-                data = np.loadtxt(fpath, skiprows=1).T
-            except Exception as ex:
-                log.error(ex)
-                continue
-
-            # X-Axis Logic
-            if rc_mode == "rmsd" and rmsd_rc is not None:
-                if len(rmsd_rc) == data.shape[1]:
-                    data[1] = rmsd_rc
-            elif rc_mode == "index":
+            if rc_mode == "index":
                 data[1] = np.arange(data.shape[1])
             elif normalize_rc:
                 data[1] = data[1] / data[1].max() if data[1].max() > 0 else data[1]
 
-            # Style Logic
-            is_last = idx == len(file_paths_to_plot) - 1
-            if highlight_last and is_last:
-                color, alpha, zorder = active_theme.highlight_color, 1.0, 20
-            else:
-                color = cm(idx / color_divisor)
-                alpha = 1.0 if idx == 0 else 0.5
-                zorder = 10 if idx == 0 else 5
-
-            # Plot
+            y_col = 2 if plot_mode == "energy" else 4
+            color = active_theme.highlight_color
             plot_energy_path(
-                ax,
-                data[1],
-                data[y_col],
-                data[3],  # Forces
-                color,
-                alpha,
-                zorder,
+                ax, data[1], data[y_col], data[3], color, 1.0, 20,
                 method=spline_method,
             )
 
-            if highlight_last and is_last and atoms_list and plot_structures != "none":
+            if atoms_list and plot_structures != "none":
                 indices = (
                     list(range(len(atoms_list)))
                     if plot_structures == "all"
@@ -838,7 +831,6 @@ def main(
                         xybox = (15.0, 60.0 if i % 2 == 0 else -60.0)
                         rad = 0.1 if i % 2 == 0 else -0.1
 
-                    # Call library function
                     plot_structure_inset(
                         ax,
                         atoms_list[i],
@@ -849,6 +841,105 @@ def main(
                         zoom=zoom_ratio,
                         rotation=ase_rotation,
                     )
+        else:
+            # eOn source: multiple .dat files
+            dat_paths = find_file_paths(input_dat_pattern)
+            file_paths_to_plot = dat_paths[start:end]
+
+            if not file_paths_to_plot:
+                log.error("No files found in range.")
+                sys.exit(1)
+
+            # Optional: Load RMSD for X-axis
+            rmsd_rc = None
+            if rc_mode == "rmsd" and atoms_list:
+                df_rmsd = compute_profile_rmsd(
+                    atoms_list, cache_file, force_recompute, ira_kmax
+                )
+                rmsd_rc = df_rmsd["r"].to_numpy()
+
+            # Plot Loop
+            cm = plt.get_cmap(active_theme.cmap_profile)
+            color_divisor = (
+                len(file_paths_to_plot) - 1 if len(file_paths_to_plot) > 1 else 1.0
+            )
+
+            y_col = 2 if plot_mode == "energy" else 4
+
+            for idx, fpath in enumerate(file_paths_to_plot):
+                try:
+                    data = np.loadtxt(fpath, skiprows=1).T
+                except Exception as ex:
+                    log.error(ex)
+                    continue
+
+                # X-Axis Logic
+                if rc_mode == "rmsd" and rmsd_rc is not None:
+                    if len(rmsd_rc) == data.shape[1]:
+                        data[1] = rmsd_rc
+                elif rc_mode == "index":
+                    data[1] = np.arange(data.shape[1])
+                elif normalize_rc:
+                    data[1] = data[1] / data[1].max() if data[1].max() > 0 else data[1]
+
+                # Style Logic
+                is_last = idx == len(file_paths_to_plot) - 1
+                if highlight_last and is_last:
+                    color, alpha, zorder = active_theme.highlight_color, 1.0, 20
+                else:
+                    color = cm(idx / color_divisor)
+                    alpha = 1.0 if idx == 0 else 0.5
+                    zorder = 10 if idx == 0 else 5
+
+                # Plot
+                plot_energy_path(
+                    ax,
+                    data[1],
+                    data[y_col],
+                    data[3],  # Forces
+                    color,
+                    alpha,
+                    zorder,
+                    method=spline_method,
+                )
+
+                if highlight_last and is_last and atoms_list and plot_structures != "none":
+                    indices = (
+                        list(range(len(atoms_list)))
+                        if plot_structures == "all"
+                        else sorted(
+                            {
+                                0,
+                                np.argmax(data[y_col][1:-1]) + 1
+                                if plot_mode == "energy"
+                                else np.argmin(data[y_col]),
+                                len(atoms_list) - 1,
+                            }
+                        )
+                    )
+                    for i in indices:
+                        if i == 0:
+                            xybox, rad = draw_reactant[:2], draw_reactant[2]
+                        elif i == len(atoms_list) - 1:
+                            xybox, rad = draw_product[:2], draw_product[2]
+                        else:
+                            xybox, rad = draw_saddle[:2], draw_saddle[2]
+
+                        if plot_structures == "all":
+                            xybox = (15.0, 60.0 if i % 2 == 0 else -60.0)
+                            rad = 0.1 if i % 2 == 0 else -0.1
+
+                        # Call library function
+                        plot_structure_inset(
+                            ax,
+                            atoms_list[i],
+                            data[1][i],
+                            data[y_col][i],
+                            xybox,
+                            rad,
+                            zoom=zoom_ratio,
+                            rotation=ase_rotation,
+                        )
 
         # --- Profile Additional Structures ---
         if additional_atoms_data and rc_mode == "rmsd":

--- a/rgpycrumbs/eon/plt_neb.py
+++ b/rgpycrumbs/eon/plt_neb.py
@@ -35,6 +35,7 @@ https://realpython.com/python-script-structure/
 #   "rich",
 #   "ase",
 #   "polars",
+#   "h5py",
 #   "chemparseplot",
 #   "rgpycrumbs",
 # ]
@@ -51,6 +52,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 from adjustText import adjust_text
+from chemparseplot.parse.trajectory.hdf5 import (
+    history_to_landscape_df as hdf5_history_to_landscape_df,
+    history_to_profile_dats,
+    result_to_atoms_list,
+    result_to_profile_dat as hdf5_result_to_profile_dat,
+)
 from chemparseplot.parse.trajectory.neb import (
     load_trajectory,
     trajectory_to_landscape_df,
@@ -144,9 +151,15 @@ IRA_KMAX_DEFAULT = 1.8
 )
 @click.option(
     "--source",
-    type=click.Choice(["eon", "traj"]),
+    type=click.Choice(["eon", "traj", "hdf5"]),
     default="eon",
-    help="Data source: 'eon' for .dat/.con pairs, 'traj' for extxyz trajectory.",
+    help="Data source: 'eon' for .dat/.con pairs, 'traj' for extxyz, 'hdf5' for ChemGP HDF5.",
+)
+@click.option(
+    "--input-h5",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Path to ChemGP NEB HDF5 file (result or history).",
 )
 @click.option(
     "--input-traj",
@@ -386,6 +399,7 @@ def main(
     # --- Data Source ---
     source,
     input_traj,
+    input_h5,
     # --- Plot Behavior ---
     plot_type,
     landscape_mode,
@@ -521,6 +535,26 @@ def main(
             # Use traj structures for con_file features when not provided
             if atoms_list is None:
                 atoms_list = traj_atoms_list
+        elif source == "hdf5":
+            if not input_h5:
+                log.critical("--input-h5 is required when --source hdf5 is used.")
+                sys.exit(1)
+            h5_str = str(input_h5)
+            # Prefer history file for multi-step landscape
+            try:
+                df = hdf5_history_to_landscape_df(h5_str, ira_kmax=ira_kmax)
+            except Exception:
+                log.warning("History read failed, falling back to single-step result.")
+                from chemparseplot.parse.trajectory.hdf5 import (
+                    result_to_atoms_list as _r2a,
+                )
+                from chemparseplot.parse.trajectory.neb import (
+                    trajectory_to_landscape_df as _traj_ldf,
+                )
+                hdf5_atoms = _r2a(h5_str)
+                df = _traj_ldf(hdf5_atoms, ira_kmax=ira_kmax)
+            if atoms_list is None:
+                atoms_list = result_to_atoms_list(h5_str)
         else:
             dat_paths = find_file_paths(input_dat_pattern)
             con_paths = find_file_paths(str(input_path_pattern))
@@ -787,7 +821,32 @@ def main(
 
     else:
         # --- Profile Plot ---
-        if source == "traj":
+        if source == "hdf5":
+            if not input_h5:
+                log.critical("--input-h5 is required when --source hdf5 is used.")
+                sys.exit(1)
+            h5_str = str(input_h5)
+            # Use history final step if available, else result
+            try:
+                dats = history_to_profile_dats(h5_str)
+                data = dats[-1]
+            except Exception:
+                data = hdf5_result_to_profile_dat(h5_str)
+            if atoms_list is None:
+                atoms_list = result_to_atoms_list(h5_str)
+
+            if rc_mode == "index":
+                data[1] = np.arange(data.shape[1])
+            elif normalize_rc:
+                data[1] = data[1] / data[1].max() if data[1].max() > 0 else data[1]
+
+            y_col = 2 if plot_mode == "energy" else 4
+            color = active_theme.highlight_color
+            plot_energy_path(
+                ax, data[1], data[y_col], data[3], color, 1.0, 20,
+                method=spline_method,
+            )
+        elif source == "traj":
             # Trajectory source: single extxyz file -> one profile
             data = trajectory_to_profile_dat(traj_atoms_list)
             if atoms_list is None:

--- a/rgpycrumbs/eon/plt_neb.py
+++ b/rgpycrumbs/eon/plt_neb.py
@@ -51,7 +51,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 from adjustText import adjust_text
-from chemparseplot.parse.chemgp.neb import (
+from chemparseplot.parse.trajectory.neb import (
     load_trajectory,
     trajectory_to_landscape_df,
     trajectory_to_profile_dat,

--- a/rgpycrumbs/eon/plt_neb.py
+++ b/rgpycrumbs/eon/plt_neb.py
@@ -52,17 +52,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 from adjustText import adjust_text
-from chemparseplot.parse.trajectory.hdf5 import (
-    history_to_landscape_df as hdf5_history_to_landscape_df,
-    history_to_profile_dats,
-    result_to_atoms_list,
-    result_to_profile_dat as hdf5_result_to_profile_dat,
-)
-from chemparseplot.parse.trajectory.neb import (
-    load_trajectory,
-    trajectory_to_landscape_df,
-    trajectory_to_profile_dat,
-)
 from chemparseplot.parse.eon.neb import (
     aggregate_neb_landscape_data,
     compute_profile_rmsd,
@@ -72,6 +61,21 @@ from chemparseplot.parse.eon.neb import (
 
 # --- Library Imports ---
 from chemparseplot.parse.file_ import find_file_paths
+from chemparseplot.parse.trajectory.hdf5 import (
+    history_to_landscape_df as hdf5_history_to_landscape_df,
+)
+from chemparseplot.parse.trajectory.hdf5 import (
+    history_to_profile_dats,
+    result_to_atoms_list,
+)
+from chemparseplot.parse.trajectory.hdf5 import (
+    result_to_profile_dat as hdf5_result_to_profile_dat,
+)
+from chemparseplot.parse.trajectory.neb import (
+    load_trajectory,
+    trajectory_to_landscape_df,
+    trajectory_to_profile_dat,
+)
 from chemparseplot.plot.neb import (
     plot_energy_path,
     plot_landscape_path_overlay,
@@ -227,6 +231,12 @@ IRA_KMAX_DEFAULT = 1.8
     ),
     default="rbf",
     help="Interpolation method for the 2D surface.",
+)
+@click.option(
+    "--n-inducing",
+    type=int,
+    default=None,
+    help="Number of inducing points for Nystrom or RFF features. Defaults to 300 (Nystrom) or 500 (RFF).",
 )
 @click.option(
     "--show-pts/--no-show-pts",
@@ -411,6 +421,7 @@ def main(
     show_pts,
     plot_mode,
     surface_type,
+    n_inducing,
     # --- Output & Slicing ---
     output_file,
     start,
@@ -551,6 +562,7 @@ def main(
                 from chemparseplot.parse.trajectory.neb import (
                     trajectory_to_landscape_df as _traj_ldf,
                 )
+
                 hdf5_atoms = _r2a(h5_str)
                 df = _traj_ldf(hdf5_atoms, ira_kmax=ira_kmax)
             if atoms_list is None:
@@ -581,7 +593,7 @@ def main(
                 augment_con=augment_con,
                 ref_atoms=atoms_list[0] if atoms_list else None,  # main reactant
                 prod_atoms=atoms_list[-1] if atoms_list else None,  # main product
-        )
+            )
 
         # Surface Generation
         if landscape_mode == "surface":
@@ -627,6 +639,7 @@ def main(
                 variance_threshold=0.5,  # 50% uncertainty
                 project_path=project_path,
                 extra_points=extra_pts_arr,
+                n_inducing=n_inducing,
             )
 
         # Path Overlay (Final Step)
@@ -811,8 +824,8 @@ def main(
 
         # Labels
         if project_path:
-            final_xlabel = xlabel or r"RMSD from Reactant ($\AA$)"
-            final_ylabel = ylabel or r"Orthogonal Deviation $d$ ($\AA$)"
+            final_xlabel = xlabel or r"Reaction progress $s$ ($\AA$)"
+            final_ylabel = ylabel or r"Orthogonal deviation $d$ ($\AA$)"
             final_title = "Reaction Valley Projection" if title == "NEB Path" else title
         else:
             final_xlabel = xlabel or r"RMSD from Reactant ($\AA$)"
@@ -843,7 +856,13 @@ def main(
             y_col = 2 if plot_mode == "energy" else 4
             color = active_theme.highlight_color
             plot_energy_path(
-                ax, data[1], data[y_col], data[3], color, 1.0, 20,
+                ax,
+                data[1],
+                data[y_col],
+                data[3],
+                color,
+                1.0,
+                20,
                 method=spline_method,
             )
         elif source == "traj":
@@ -860,7 +879,13 @@ def main(
             y_col = 2 if plot_mode == "energy" else 4
             color = active_theme.highlight_color
             plot_energy_path(
-                ax, data[1], data[y_col], data[3], color, 1.0, 20,
+                ax,
+                data[1],
+                data[y_col],
+                data[3],
+                color,
+                1.0,
+                20,
                 method=spline_method,
             )
 
@@ -962,7 +987,12 @@ def main(
                     method=spline_method,
                 )
 
-                if highlight_last and is_last and atoms_list and plot_structures != "none":
+                if (
+                    highlight_last
+                    and is_last
+                    and atoms_list
+                    and plot_structures != "none"
+                ):
                     indices = (
                         list(range(len(atoms_list)))
                         if plot_structures == "all"
@@ -1055,18 +1085,24 @@ def main(
     if plot_type == "landscape" and not aspect_ratio:
         ax.set_aspect("equal")
         if project_path:
-            # Force Y-axis to be symmetric and match the X-axis span
+            # Force Y-axis to be symmetric and match the X-axis span,
+            # but expand if additional structures fall outside
             x_min, x_max = ax.get_xlim()
             x_span = x_max - x_min
             half_span = x_span / 2
+            if additional_atoms_data:
+                for _, add_r, add_p, _ in additional_atoms_data:
+                    add_d = (add_r - r_start) * v_r + (add_p - p_start) * v_p
+                    half_span = max(half_span, abs(add_d) * 1.15)
             ax.set_ylim(-half_span, half_span)
             log.info(f"Set symmetric Y-axis limits: [-{half_span:.2f}, {half_span:.2f}]")
 
     if show_legend:
         ax.legend(
-            # Upper left is orthogonal to 0 distance from R, unlikely
-            # Lower left is near 0 w.r.t R and P, always spurious
-            loc="upper left" if project_path else "lower left",
+            # In (s,d) space markers can appear anywhere, so let
+            # matplotlib pick the least-overlapping corner.
+            # In raw RMSD-RMSD the lower left is always empty.
+            loc="best" if project_path else "lower left",
             borderaxespad=0.5,
             frameon=True,
             framealpha=1.0,
@@ -1075,16 +1111,18 @@ def main(
             fontsize=int(active_theme.font_size * 0.8),
         ).set_zorder(101)
 
+    plt.tight_layout(pad=0.5)
+
     if ax_strip:
         pos_main = ax.get_position()
         pos_strip = ax_strip.get_position()
 
-        # Force strip to match the main plot's Left and Width exactly
+        # Force strip to match the main plot's Left and Width exactly,
+        # and push it down slightly to avoid overlapping the xlabel
+        strip_y = pos_strip.y0 - 0.02
         ax_strip.set_position(
-            [pos_main.x0, pos_strip.y0, pos_main.width, pos_strip.height]
+            [pos_main.x0, strip_y, pos_main.width, pos_strip.height]
         )
-
-    plt.tight_layout(pad=0.5)
 
     if output_file:
         plt.savefig(output_file, transparent=False, bbox_inches="tight", dpi=dpi)

--- a/rgpycrumbs/geom/api/alignment.py
+++ b/rgpycrumbs/geom/api/alignment.py
@@ -155,6 +155,17 @@ def align_structure_robust(
     return AlignmentResult(atoms=mobile_atoms, method=AlignmentMethod.ASE_PROCRUSTES)
 
 
+def _rmsd_single(ref_atom, atom_i, config, coords_ref):
+    """Align one image and return its RMSD (thread-safe on a copy)."""
+    if atom_i is ref_atom:
+        return 0.0
+    mobile_copy = atom_i.copy()
+    align_structure_robust(ref_atom, mobile_copy, config)
+    coords_aligned = mobile_copy.get_positions()
+    diff_sq = (coords_ref - coords_aligned) ** 2
+    return float(np.sqrt(np.mean(np.sum(diff_sq, axis=1))))
+
+
 def calculate_rmsd_from_ref(
     atoms_list: list[Atoms], ira_instance, ref_atom: Atoms, ira_kmax: float
 ) -> np.ndarray:
@@ -165,36 +176,28 @@ def calculate_rmsd_from_ref(
     If IRA fails or lacks the necessary library, the code falls back to
     standard ASE Procrustes alignment via `align_structure_robust`.
 
+    Alignment of individual images is parallelized over threads; the
+    IRA Fortran library and numpy both release the GIL.
+
     :param atoms_list: A list of ASE Atoms objects.
     :param ira_instance: An instantiated IRA object (or None).
     :param ref_atom: The reference Atoms object to align against.
     :param ira_kmax: kmax factor for IRA.
     :return: An array of RMSD values.
     """
-    rmsd_values = np.zeros(len(atoms_list))
-    coords_ref = ref_atom.get_positions()
+    import os
+    from concurrent.futures import ThreadPoolExecutor
 
-    # Configure IRA based on the presence of the instance
     config = IRAConfig(enabled=(ira_instance is not None), kmax=ira_kmax)
+    coords_ref = ref_atom.get_positions()
+    n = len(atoms_list)
+    workers = min(n, os.cpu_count() or 4)
 
-    for i, atom_i in enumerate(atoms_list):
-        if atom_i is ref_atom:
-            rmsd_values[i] = 0.0
-            continue
-
-        # Create a working copy to avoid mutating the original trajectory
-        mobile_copy = atom_i.copy()
-
-        align_structure_robust(
-            ref_atom,
-            mobile_copy,
-            config,
-        )
-
-        # Calculate RMSD: $\sqrt{\frac{1}{N} \sum (r_{ref} - r_{aligned})^2}$
-        coords_aligned = mobile_copy.get_positions()
-        diff_sq = (coords_ref - coords_aligned) ** 2
-        rmsd = np.sqrt(np.mean(np.sum(diff_sq, axis=1)))
-        rmsd_values[i] = rmsd
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [
+            pool.submit(_rmsd_single, ref_atom, atoms_list[i], config, coords_ref)
+            for i in range(n)
+        ]
+        rmsd_values = np.array([f.result() for f in futures])
 
     return rmsd_values

--- a/rgpycrumbs/surfaces/__init__.py
+++ b/rgpycrumbs/surfaces/__init__.py
@@ -18,6 +18,19 @@ from rgpycrumbs.surfaces.gradient import (
 )
 from rgpycrumbs.surfaces.standard import FastIMQ, FastMatern, FastTPS
 
+NYSTROM_THRESHOLD = 1000
+NYSTROM_N_INDUCING_DEFAULT = 300
+
+
+def nystrom_paths_needed(n_inducing, images_per_step):
+    """Number of optimization steps the Nystrom approximation actually samples.
+
+    Mirrors the structured sampling in :class:`NystromGradientIMQ._fit`:
+    ``paths_to_sample = max(1, n_inducing // nimags)``, plus one buffer step.
+    """
+    return max(1, -(-n_inducing // images_per_step)) + 1  # ceil div + buffer
+
+
 __all__ = [
     "BaseGradientSurface",
     "BaseSurface",
@@ -28,12 +41,15 @@ __all__ = [
     "GradientMatern",
     "GradientRQ",
     "GradientSE",
+    "NYSTROM_N_INDUCING_DEFAULT",
+    "NYSTROM_THRESHOLD",
     "NystromGradientIMQ",
     "_imq_kernel_matrix",
     "_matern_kernel_matrix",
     "_tps_kernel_matrix",
     "generic_negative_mll",
     "get_surface_model",
+    "nystrom_paths_needed",
     "safe_cholesky_solve",
 ]
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -13,7 +13,9 @@ from ase.build import molecule  # noqa: E402
 from rgpycrumbs.geom.api.alignment import (  # noqa: E402
     AlignmentMethod,
     IRAConfig,
+    _rmsd_single,
     align_structure_robust,
+    calculate_rmsd_from_ref,
     ira_mod,
 )
 
@@ -235,3 +237,104 @@ class TestStructuralAlignment:
         except ValueError:
             # If libira raises an error due to no congruent match found, that is also valid.
             pass
+
+
+class TestParallelRMSD:
+    """Tests for the parallelized RMSD calculation."""
+
+    @staticmethod
+    def _make_path(ref, n_images=6, max_disp=0.5):
+        """Build a synthetic NEB-like path by progressively distorting atom positions.
+
+        Uses internal distortions (not rigid-body transforms) so that
+        Procrustes alignment cannot remove the displacement.
+        """
+        path = [ref.copy()]
+        rng = np.random.default_rng(42)
+        # Fixed random direction per atom, scaled by image index
+        direction = rng.standard_normal(ref.positions.shape)
+        direction /= np.linalg.norm(direction)
+        for i in range(1, n_images):
+            img = ref.copy()
+            scale = max_disp * i / (n_images - 1)
+            img.positions += direction * scale
+            path.append(img)
+        return path
+
+    def test_reference_image_has_zero_rmsd(self, water_molecule):
+        """RMSD of the reference with itself must be exactly 0."""
+        path = self._make_path(water_molecule, n_images=5)
+        # ref_atom is the first element of path (same object)
+        rmsd = calculate_rmsd_from_ref(
+            path, ira_instance=None, ref_atom=path[0], ira_kmax=1.8
+        )
+        assert rmsd[0] == 0.0
+
+    def test_rmsd_values_non_negative(self, water_molecule):
+        """All RMSD values must be >= 0."""
+        path = self._make_path(water_molecule, n_images=8)
+        rmsd = calculate_rmsd_from_ref(
+            path, ira_instance=None, ref_atom=path[0], ira_kmax=1.8
+        )
+        assert np.all(rmsd >= 0.0)
+
+    def test_rmsd_increases_along_path(self, water_molecule):
+        """For a monotonically distorted path, RMSD from the first image should increase."""
+        path = self._make_path(water_molecule, n_images=6)
+        rmsd = calculate_rmsd_from_ref(
+            path, ira_instance=None, ref_atom=path[0], ira_kmax=1.8
+        )
+        # Each successive image has larger internal distortion, so RMSD grows
+        for i in range(1, len(rmsd)):
+            assert rmsd[i] > rmsd[i - 1], f"RMSD[{i}] not > RMSD[{i-1}]"
+
+    def test_parallel_matches_sequential(self, water_molecule):
+        """Parallel calculation must produce the same values as a sequential loop."""
+        path = self._make_path(water_molecule, n_images=10)
+        ref = path[0]
+        config = IRAConfig(enabled=False, kmax=1.8)
+        coords_ref = ref.get_positions()
+
+        # Sequential baseline
+        sequential = np.array([
+            _rmsd_single(ref, img, config, coords_ref) for img in path
+        ])
+
+        # Parallel via calculate_rmsd_from_ref
+        parallel = calculate_rmsd_from_ref(
+            path, ira_instance=None, ref_atom=ref, ira_kmax=1.8
+        )
+
+        np.testing.assert_allclose(parallel, sequential, atol=1e-12)
+
+    def test_single_image_path(self, water_molecule):
+        """Edge case: path with a single image (the reference itself)."""
+        path = [water_molecule.copy()]
+        rmsd = calculate_rmsd_from_ref(
+            path, ira_instance=None, ref_atom=path[0], ira_kmax=1.8
+        )
+        assert rmsd.shape == (1,)
+        assert rmsd[0] == 0.0
+
+    def test_product_reference(self, water_molecule):
+        """RMSD from the last image should be zero for that image, nonzero for others."""
+        path = self._make_path(water_molecule, n_images=6)
+        rmsd_p = calculate_rmsd_from_ref(
+            path, ira_instance=None, ref_atom=path[-1], ira_kmax=1.8
+        )
+        assert rmsd_p[-1] == 0.0
+        # All other images should have positive RMSD from product
+        assert np.all(rmsd_p[:-1] > 0.0)
+
+    @requires_ira
+    def test_parallel_with_ira(self, water_molecule):
+        """Parallel RMSD with IRA enabled should still produce consistent results."""
+        path = self._make_path(water_molecule, n_images=6)
+        ira_instance = ira_mod.IRA()
+
+        rmsd = calculate_rmsd_from_ref(
+            path, ira_instance=ira_instance, ref_atom=path[0], ira_kmax=1.8
+        )
+        assert rmsd[0] == 0.0
+        assert np.all(rmsd >= 0.0)
+        assert rmsd.shape == (6,)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,3 +66,12 @@ def test_cli_verbose_output(mock_run, runner, mock_script_group):  # noqa: ARG00
     # Check that our verbose click.echo statements fired
     assert "VERBOSE: Resolved script path ->" in result.output
     assert "VERBOSE: Constructed command -> uv run" in result.output
+
+
+def test_plt_neb_strip_renderer_option(runner):
+    """Verify --strip-renderer appears in plt-neb help output."""
+    from rgpycrumbs.eon.plt_neb import main as plt_neb_main
+
+    result = runner.invoke(plt_neb_main, ["--help"])
+    assert result.exit_code == 0
+    assert "--strip-renderer" in result.output


### PR DESCRIPTION
## Summary

- Adds `--source traj` and `--input-traj` options to `plt_neb` for plotting NEB profiles and landscapes directly from extxyz trajectory files
- Adds `--source hdf5` and `--input-h5` options to `plt_neb` for plotting from ChemGP HDF5 output (neb_result.h5 / neb_history.h5)
- Updates import path from `chemparseplot.parse.chemgp.neb` to `chemparseplot.parse.trajectory.neb` following the upstream rename

## Changes

- `rgpycrumbs/eon/plt_neb.py`:
  - Trajectory source branching alongside existing eOn source
  - HDF5 source with history-to-result fallback for both profile and landscape
  - Updated import path and script dependency list

## Checklist

- [ ] CI passes
- [ ] Requires chemparseplot >= next release (companion PR: HaoZeke/chemparseplot#9)