### PR TITLE
Suite hub DRY: AUTO_DEPS, suite_pins, basetypes re-export, surface_fit_config

### DIFF
--- a/docs/examples/rgpkgs.config.toml
+++ b/docs/examples/rgpkgs.config.toml
@@ -1,4 +1,5 @@
-# Ecosystem config for the rgpkgs suite (rgpycrumbs, chemparseplot, …).
+# Ecosystem config for the rgpkgs suite (rgpycrumbs, chemparseplot, pychum, …).
+# CON/convel I/O: readcon-core (https://github.com/lode-org/readcon-core).
 #
 # Install:
 #   mkdir -p ~/.config/rgpkgs

--- a/docs/orgmode/explanation/public_api.org
+++ b/docs/orgmode/explanation/public_api.org
@@ -12,6 +12,7 @@ from rgpycrumbs.api import (
     apply_pin_to_spec,
     pins_from_env,
     ensure_import,
+    suite_pins,
     resolve_lock_path_layered,
     user_config_path,
 )
@@ -24,6 +25,7 @@ from rgpycrumbs.api import (
 | ~apply_pin_to_spec~ | Apply pin map to a pip requirement string |
 | ~pins_from_env~ | Read ~RGPKGS_LOCK_PINS~ (set by CLI dispatch) |
 | ~ensure_import~ | On-demand optional import (+ AUTO_DEPS) |
+| ~suite_pins~ | Env ∪ config pin merge for consumers |
 | ~resolve_lock_path_layered~ | CLI > env > config lock path |
 | ~user_config_path~ | Path to global TOML |
 
@@ -63,3 +65,18 @@ advanced use; plot stacks may need optional deps until fully on-demand.
 - Env ~RGPKGS_LOCK~, ~RGPKGS_CONFIG~, ~RGPKGS_FORCE_UV~, ~RGPKGS_AUTO_DEPS~
 
 Hub has *no* runtime feature extras. Do not ~pip install "rgpycrumbs[analysis]"~.
+
+
+* CON I/O (~readcon-core~ / ~chemparseplot.parse.con~)
+
+eOn CON/convel frames use [[https://github.com/lode-org/readcon-core][readcon-core]]
+(PyPI package name ~readcon~). Prefer:
+
+#+BEGIN_SRC python
+from chemparseplot.api import load_trajectory, plot_con_overview
+
+traj = load_trajectory("movie.con")
+fig = plot_con_overview(traj, structures="endpoints")
+#+END_SRC
+
+CLI: ~rgpycrumbs eon plt-con movie.con~

--- a/docs/orgmode/explanation/suite_architecture.org
+++ b/docs/orgmode/explanation/suite_architecture.org
@@ -8,6 +8,7 @@
 | rgpycrumbs | Hub: CLI, ensure_import, locks, suite TOML |
 | chemparseplot | Parse + plot library (no second config tree) |
 | pychum | Input generators |
+| [[https://github.com/lode-org/readcon-core][readcon-core]] | CON/convel I/O (Rust; PyPI: [[https://pypi.org/project/readcon/][readcon]]) |
 
 * Config
 
@@ -24,3 +25,8 @@ functions; today full pipelines still go through ~rgpycrumbs eon plt-*~.
 * Locks
 
 Consume (not produce): uv.lock, PEP 751 pylock, CycloneDX (eb-stack / uv export).
+
+* CON / structure I/O
+
+eOn movies and general CON trajectories use ~readcon-core~ (import name
+~readcon~) via ~chemparseplot.parse.con~. See also ~rgpycrumbs eon plt-con~.

--- a/docs/orgmode/index.org
+++ b/docs/orgmode/index.org
@@ -42,6 +42,7 @@ digraph G {
     rgpycrumbs [label="rgpycrumbs\n(Core Utilities & Dispatcher)", fillcolor="#fff9c4"];
     pychum [label="pychum\n(Input Generation)", fillcolor="#e1f5fe"];
     chemparseplot [label="chemparseplot\n(Parsers & Plotting)", fillcolor="#e1f5fe"];
+    readcon [label="readcon-core\n(CON / convel I/O)", fillcolor="#e8f5e9", URL="https://github.com/lode-org/readcon-core"];
 
     eon [label="eOn", fillcolor="#f5f5f5"];
     orca [label="ORCA", fillcolor="#f5f5f5"];
@@ -52,12 +53,15 @@ digraph G {
 
     chemparseplot -> rgpycrumbs [label="imports from"];
     pychum -> rgpycrumbs [label="imports from"];
+    chemparseplot -> readcon [label="CON frames", color="#2e7d32"];
+    rgpycrumbs -> readcon [label="eOn movies", color="#2e7d32", style=dashed];
 
     pychum -> eon [label="generates input for", style=dashed];
     pychum -> orca [label="generates input for", style=dashed];
 
     chemparseplot -> eon [label="parses output from", style=dashed];
     chemparseplot -> orca [label="parses output from", style=dashed];
+    eon -> readcon [label="writes CON", style=dashed];
 
     rgpycrumbs -> eon [label="manages / visualizes", color="#4caf50"];
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,6 +114,12 @@ html_theme_options = {
                     "summary": "Input file generation for ORCA and NWChem",
                     "external": True,
                 },
+                {
+                    "title": "readcon-core",
+                    "url": "https://github.com/lode-org/readcon-core",
+                    "summary": "CON/convel I/O (Rust core; PyPI: readcon)",
+                    "external": True,
+                },
             ],
         },
         {

--- a/rgpycrumbs/_aux.py
+++ b/rgpycrumbs/_aux.py
@@ -79,6 +79,8 @@ def warn_on_direct_script_import(
         return
     if os.environ.get(auto_env, "").strip() == "1":
         return
+    if _auto_deps_enabled():
+        return
     warnings.warn(
         (
             f"{module_name} is a dispatched PEP 723 script. Direct imports bypass the "
@@ -89,6 +91,24 @@ def warn_on_direct_script_import(
         ),
         stacklevel=2,
     )
+
+
+# Keep in sync with rgpycrumbs.config.AUTO_DEPS_ENVS (avoid importing config
+# from _aux: ensure_import is used during early bootstrap / circular paths).
+_AUTO_DEPS_ENVS = ("RGPKGS_AUTO_DEPS", "RGPYCRUMBS_AUTO_DEPS")
+
+
+def _auto_deps_enabled() -> bool:
+    """True when suite AUTO_DEPS opt-in is set (RGPKGS_* first, then legacy).
+
+    Library callers should set ``RGPKGS_AUTO_DEPS=1`` (ecosystem name).
+    ``RGPYCRUMBS_AUTO_DEPS`` remains as a legacy alias. CLI dispatch still
+    materializes the resolved default into the process env before scripts run.
+
+    Does **not** change the PEP 723 + uv isolation design for CLIs, and does
+    not enable auto-install unless an env flag is explicitly ``1``.
+    """
+    return any(os.environ.get(name, "").strip() == "1" for name in _AUTO_DEPS_ENVS)
 
 
 def enable_library_auto_deps() -> None:
@@ -200,12 +220,16 @@ def ensure_import(module_name: str):
     1. Current environment (importlib)
     2. Parent environment (RGPYCRUMBS_PARENT_SITE_PACKAGES)
     3. uv cache directory on sys.path
-    4. uv/pip install into cache (opt-in via RGPYCRUMBS_AUTO_DEPS=1)
+    4. uv/pip install into cache (opt-in via ``RGPKGS_AUTO_DEPS=1`` or
+       legacy ``RGPYCRUMBS_AUTO_DEPS=1``)
     5. Raise ImportError with an actionable message
 
     Returns the imported module object.
 
     .. versionadded:: 1.3.0
+    .. versionchanged:: 1.10.5
+       Auto-deps respects ``RGPKGS_AUTO_DEPS`` (ecosystem) as well as the
+       legacy ``RGPYCRUMBS_AUTO_DEPS`` name, matching :data:`AUTO_DEPS_ENVS`.
     """
     # Step 1: current env
     try:
@@ -228,9 +252,8 @@ def ensure_import(module_name: str):
         except ImportError:
             pass
 
-    # Step 4: auto-install (opt-in)
-    auto = os.environ.get("RGPYCRUMBS_AUTO_DEPS", "").strip()
-    if auto == "1" and module_name in _DEPENDENCY_MAP:
+    # Step 4: auto-install (opt-in; never default-on for library imports)
+    if _auto_deps_enabled() and module_name in _DEPENDENCY_MAP:
         spec = _resolve_pip_spec(module_name)
         try:
             _uv_install(spec, cache_dir)
@@ -258,7 +281,8 @@ Install the package:
   pip install "{spec}"
 
 Or enable auto-install (CLI dispatch does this by default):
-  export RGPYCRUMBS_AUTO_DEPS=1
+  export RGPKGS_AUTO_DEPS=1
+  # legacy alias: RGPYCRUMBS_AUTO_DEPS=1
 
 For GPU support:
   pip install "jax[cuda12]"  # CUDA 12
@@ -272,7 +296,8 @@ See: https://jax.readthedocs.io/en/latest/installation.html
                 f"Install with:\n"
                 f'  pip install "{spec}"\n\n'
                 f"Or enable auto-install:\n"
-                f"  export RGPYCRUMBS_AUTO_DEPS=1"
+                f"  export RGPKGS_AUTO_DEPS=1\n"
+                f"  # legacy alias: RGPYCRUMBS_AUTO_DEPS=1"
             )
     else:
         msg = (

--- a/rgpycrumbs/api.py
+++ b/rgpycrumbs/api.py
@@ -55,5 +55,23 @@ __all__ = [
     "resolve_auto_deps_default",
     "resolve_force_uv",
     "resolve_lock_path_layered",
+    "suite_pins",
     "user_config_path",
 ]
+
+
+def suite_pins() -> dict[str, str]:
+    """Merged package pins: ``RGPKGS_LOCK_PINS`` / env pins ∪ layered config.
+
+    Single implementation for the suite. Consumers (chemparseplot, wailord)
+    should re-export or call this rather than reimplementing the merge.
+
+    Soft-fails to env-only pins if config load errors (never raises for missing
+    config files). Does not install packages and does not require uv.
+    """
+    pins = dict(pins_from_env())
+    try:
+        pins.update(load_config().merged_package_pins_normalized())
+    except Exception:  # noqa: BLE001 — soft fail for consumers
+        pass
+    return pins

--- a/rgpycrumbs/api.py
+++ b/rgpycrumbs/api.py
@@ -61,7 +61,7 @@ __all__ = [
 
 
 def suite_pins() -> dict[str, str]:
-    """Merged package pins: ``RGPKGS_LOCK_PINS`` / env pins ∪ layered config.
+    """Merged package pins: ``RGPKGS_LOCK_PINS`` / env pins or layered config.
 
     Single implementation for the suite. Consumers (chemparseplot, wailord)
     should re-export or call this rather than reimplementing the merge.
@@ -72,6 +72,6 @@ def suite_pins() -> dict[str, str]:
     pins = dict(pins_from_env())
     try:
         pins.update(load_config().merged_package_pins_normalized())
-    except Exception:  # noqa: BLE001 — soft fail for consumers
-        pass
+    except (OSError, ValueError, TypeError, AttributeError, ImportError):
+        return pins
     return pins

--- a/rgpycrumbs/api.py
+++ b/rgpycrumbs/api.py
@@ -23,6 +23,8 @@ See ``docs/orgmode/explanation/public_api.org`` and suite architecture docs.
 
 from __future__ import annotations
 
+import logging
+
 from rgpycrumbs._aux import ensure_import, lazy_import
 from rgpycrumbs.config import (
     CONFIG_PATH_ENV,
@@ -72,6 +74,6 @@ def suite_pins() -> dict[str, str]:
     pins = dict(pins_from_env())
     try:
         pins.update(load_config().merged_package_pins_normalized())
-    except (OSError, ValueError, TypeError, AttributeError, ImportError):
-        return pins
+    except Exception as exc:
+        logging.getLogger(__name__).debug("suite_pins: config load skipped: %s", exc)
     return pins

--- a/rgpycrumbs/basetypes.py
+++ b/rgpycrumbs/basetypes.py
@@ -1,119 +1,86 @@
-import datetime
-from dataclasses import dataclass, field
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+"""Typed records for NEB / saddle data.
 
-import numpy as np
+Canonical definitions live in ``chemparseplot.basetypes``. This module
+re-exports them for backward compatibility. Prefer importing from
+chemparseplot in new parse/plot library code.
 
+When chemparseplot is not installed (hub-only environment), a local
+fallback copy is used so pure hub tests still import.
+"""
 
-@dataclass(frozen=True, slots=True)
-class nebiter:
-    """
-        A typed record representing an iteration of a Nudged Elastic Band (NEB) calculation.
+from __future__ import annotations
 
-    .. versionadded:: 1.0.0
+try:
+    from chemparseplot.basetypes import (
+        DimerOpt,
+        MolGeom,
+        SaddleMeasure,
+        SpinID,
+        nebiter,
+        nebpath,
+    )
+except ImportError:  # pragma: no cover - hub-only fallback
+    import datetime
+    from dataclasses import dataclass, field
 
-    Parameters
-    ----------
-    iteration : int
-        The iteration number of the NEB calculation.
-    nebpath : nebpath
-        The data for the NEB path at this iteration.
+    import numpy as np
 
-    See Also
-    --------
-    nebpath : Stores the normalized arclength, actual arclength, and energy data for
-        the NEB path.
-    """
+    @dataclass(frozen=True, slots=True)
+    class nebpath:
+        norm_dist: float
+        arc_dist: float
+        energy: float
 
-    iteration: int
-    nebpath: "nebpath"
+    @dataclass(frozen=True, slots=True)
+    class nebiter:
+        iteration: int
+        nebpath: nebpath
 
+    @dataclass
+    class DimerOpt:
+        saddle: str = "dimer"
+        rot: str = "lbfgs"
+        trans: str = "lbfgs"
 
-@dataclass(frozen=True, slots=True)
-class nebpath:
-    """
-        A typed record representing the NEB path data.
+    @dataclass
+    class SpinID:
+        mol_id: int
+        spin: str
 
-    .. versionadded:: 1.0.0
+    @dataclass
+    class MolGeom:
+        pos: np.ndarray
+        energy: float
+        forces: np.ndarray
 
-    Parameters
-    ----------
-    norm_dist : float
-        Normalized Arclength (0 to 1), representing the progression along the reaction path.
-        Calculated as xcoord2 = arcS[img] / arcS[nim-1].
-    arc_dist : float
-        Actual Arclength at each point along the reaction path. Calculated as
-        xcoord = arcS[img] + dx(ii).
-    energy : float
-        Interpolated Energy at each point, calculated using cubic polynomial
-        interpolation. The energy is calculated using the formula:
-        p = a*pow(dx(ii), 3.0) + b*pow(dx(ii), 2.0) + c*dx(ii) + d,
-        where a, b, c, and d are coefficients of the cubic polynomial.
+    @dataclass
+    class SaddleMeasure:
+        pes_calls: int = 0
+        iter_steps: int = 0
+        tot_time: float = field(
+            default_factory=lambda: datetime.timedelta(0).total_seconds()
+        )
+        saddle_energy: float = np.nan
+        saddle_fmax: float = np.nan
+        success: bool = False
+        method: str = "not run"
+        dimer_rot: str = "n/a"
+        dimer_trans: str = "n/a"
+        init_energy: float = np.nan
+        barrier: float = np.nan
+        mol_id: int = np.nan
+        spin: str = "unknown"
+        scf: float = np.nan
+        termination_status: str = "not set"
 
-    Notes
-    -----
-    The `nebpath` record is used within the `nebiter` record to store
-    detailed path information for each NEB iteration.
-    """
-
-    norm_dist: float
-    arc_dist: float
-    energy: float
-
-
-@dataclass
-class DimerOpt:
-    """Configuration for a dimer-based saddle point search.
-
-    .. versionadded:: 1.0.0
-    """
-
-    saddle: str = "dimer"
-    rot: str = "lbfgs"
-    trans: str = "lbfgs"
-
-
-@dataclass
-class SpinID:
-    """Identifier combining molecule ID and spin state.
-
-    .. versionadded:: 1.0.0
-    """
-
-    mol_id: int
-    spin: str
-
-
-@dataclass
-class MolGeom:
-    """Container for molecular geometry with energy and forces.
-
-    .. versionadded:: 1.0.0
-    """
-
-    pos: np.array
-    energy: float
-    forces: np.array
-
-
-@dataclass
-class SaddleMeasure:
-    """Aggregated measurements from a saddle point search.
-
-    .. versionadded:: 1.0.0
-    """
-
-    pes_calls: int = 0
-    iter_steps: int = 0
-    tot_time: float = field(default_factory=lambda: datetime.timedelta(0).total_seconds())
-    saddle_energy: float = np.nan
-    saddle_fmax: float = np.nan
-    success: bool = False
-    method: str = "not run"
-    dimer_rot: str = "n/a"
-    dimer_trans: str = "n/a"
-    init_energy: float = np.nan
-    barrier: float = np.nan
-    mol_id: int = np.nan
-    spin: str = "unknown"
-    scf: float = np.nan
-    termination_status: str = "not set"
+__all__ = [
+    "DimerOpt",
+    "MolGeom",
+    "SaddleMeasure",
+    "SpinID",
+    "nebiter",
+    "nebpath",
+]

--- a/rgpycrumbs/basetypes.py
+++ b/rgpycrumbs/basetypes.py
@@ -76,6 +76,7 @@ except ImportError:  # pragma: no cover - hub-only fallback
         scf: float = np.nan
         termination_status: str = "not set"
 
+
 __all__ = [
     "DimerOpt",
     "MolGeom",

--- a/rgpycrumbs/chemgp/__init__.py
+++ b/rgpycrumbs/chemgp/__init__.py
@@ -2,34 +2,57 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""ChemGP plotting and I/O utilities.
+"""ChemGP plotting and I/O utilities (compatibility re-exports).
 
-Parsing and plotting functions live in chemparseplot. This module
-re-exports them for backward compatibility. The CLI entry point
-is plot_gp.py (PEP 723 script dispatched by rgpycrumbs.cli).
+Parsing and plotting live in **chemparseplot**. This package re-exports them
+for backward compatibility. Prefer::
+
+    from chemparseplot.plot.chemgp import plot_surface_contour
+    from chemparseplot.parse.chemgp_hdf5 import read_h5_points
+
+The CLI entry point remains ``plot_gp.py`` (PEP 723, dispatched by
+``rgpycrumbs.cli``).
 """
 
-from chemparseplot.parse.chemgp_hdf5 import (
-    read_h5_grid,
-    read_h5_metadata,
-    read_h5_path,
-    read_h5_points,
-    read_h5_table,
+from __future__ import annotations
+
+import warnings
+
+warnings.warn(
+    "rgpycrumbs.chemgp library re-exports are deprecated; import from "
+    "chemparseplot.plot.chemgp / chemparseplot.parse.chemgp_hdf5 instead. "
+    "The plot_gp CLI under rgpycrumbs remains supported.",
+    DeprecationWarning,
+    stacklevel=2,
 )
-from chemparseplot.plot.chemgp import (
-    detect_clamp,
-    plot_convergence_curve,
-    plot_energy_profile,
-    plot_fps_projection,
-    plot_gp_progression,
-    plot_hyperparameter_sensitivity,
-    plot_nll_landscape,
-    plot_rff_quality,
-    plot_surface_contour,
-    plot_trust_region,
-    plot_variance_overlay,
-    save_plot,
-)
+
+try:
+    from chemparseplot.parse.chemgp_hdf5 import (
+        read_h5_grid,
+        read_h5_metadata,
+        read_h5_path,
+        read_h5_points,
+        read_h5_table,
+    )
+    from chemparseplot.plot.chemgp import (
+        detect_clamp,
+        plot_convergence_curve,
+        plot_energy_profile,
+        plot_fps_projection,
+        plot_gp_progression,
+        plot_hyperparameter_sensitivity,
+        plot_nll_landscape,
+        plot_rff_quality,
+        plot_surface_contour,
+        plot_trust_region,
+        plot_variance_overlay,
+        save_plot,
+    )
+except ImportError as exc:  # pragma: no cover - env without plot stack
+    raise ImportError(
+        "rgpycrumbs.chemgp requires chemparseplot[plot,neb] (and pandas). "
+        "Prefer importing chemparseplot.plot.chemgp directly."
+    ) from exc
 
 # Backward-compatible aliases for old names
 plot_convergence = plot_convergence_curve

--- a/rgpycrumbs/eon/__init__.py
+++ b/rgpycrumbs/eon/__init__.py
@@ -13,7 +13,7 @@
     plot_min(job_dir="minimization_run", plot_type="landscape", output="min.png")
     plot_saddle(job_dir="saddle_run", plot_type="profile", output="sad.png")
 
-CLI: ``rgpycrumbs eon plt-{neb,min,saddle}`` (same pipelines).
+CLI: ``rgpycrumbs eon plt-{neb,min,saddle,con}`` (same pipelines).
 """
 
 from __future__ import annotations

--- a/rgpycrumbs/eon/plot_config.py
+++ b/rgpycrumbs/eon/plot_config.py
@@ -162,8 +162,6 @@ def _coerce_value(key: str, value: Any) -> Any:
         return (value,)
     if key == "label" and isinstance(value, list):
         return tuple(value)
-    if key == "job_dir" and isinstance(value, list):
-        return tuple(Path(item) for item in value)
     return value
 
 
@@ -261,17 +259,14 @@ def merge_plot_settings(
     if "job_dir" in settings and settings["job_dir"] is not None:
         jd = settings["job_dir"]
         if isinstance(jd, (str, Path)):
-            settings["job_dir"] = (Path(jd),)
-        elif isinstance(jd, list):
-            settings["job_dir"] = tuple(Path(p) for p in jd)
-        elif isinstance(jd, tuple):
-            settings["job_dir"] = tuple(Path(p) for p in jd)
+            jd = [jd]
+        settings["job_dir"] = tuple(Path(p) for p in jd)
 
     if "label" in settings and settings["label"] is not None:
         lab = settings["label"]
         if isinstance(lab, str):
-            settings["label"] = (lab,)
-        elif isinstance(lab, list):
+            lab = [lab]
+        if isinstance(lab, (list, tuple)):
             settings["label"] = tuple(lab)
 
     return settings
@@ -309,6 +304,33 @@ def resolve_from_click(
         cli_overrides=overrides,
         passthrough=params,
     )
+
+
+def surface_fit_config(settings: dict[str, Any]):
+    """Build chemparseplot ``SurfaceFitConfig`` from a resolved settings dict.
+
+    Single place that maps TOML / CLI ``auto_thin`` and ``max_surface_points``
+    onto the library plot type. Falls back to a tiny namespace if chemparseplot
+    is not installed (CLI pure-config tests).
+    """
+    auto_thin = bool(settings.get("auto_thin", SHARED_DEFAULTS["auto_thin"]))
+    max_surface_points = int(
+        settings.get("max_surface_points", SHARED_DEFAULTS["max_surface_points"])
+    )
+    try:
+        from chemparseplot.plot.neb import SurfaceFitConfig
+
+        return SurfaceFitConfig(
+            auto_thin=auto_thin,
+            max_surface_points=max_surface_points,
+        )
+    except ImportError:  # pragma: no cover
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            auto_thin=auto_thin,
+            max_surface_points=max_surface_points,
+        )
 
 
 def run_plot(

--- a/rgpycrumbs/eon/plt_con.py
+++ b/rgpycrumbs/eon/plt_con.py
@@ -25,6 +25,7 @@ Unlike ``plt-min`` / ``plt-neb``, no eOn job directory or sidecar ``.dat``.
 from __future__ import annotations
 
 import logging
+import math
 from pathlib import Path
 
 import click
@@ -139,7 +140,7 @@ def main(
     paths = list(con_files)
     trajs = [load_trajectory(p) for p in paths]
     for p, traj in zip(paths, trajs, strict=False):
-        n_e = int(sum(1 for v in traj.energies if v == v))
+        n_e = int(sum(1 for v in traj.energies if math.isfinite(v)))
         log.info(
             "Loaded %s: %d frames, energy finite=%d, forces=%s, source=%s",
             p.name,

--- a/rgpycrumbs/eon/plt_con.py
+++ b/rgpycrumbs/eon/plt_con.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Plot general readcon CON (or chemfiles) trajectories.
+
+Energy/force profiles, multi-file overlays, optional structure strips.
+Unlike ``plt-min`` / ``plt-neb``, no eOn job directory or sidecar ``.dat``.
+
+.. versionadded:: 1.10.5
+"""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "click",
+#   "matplotlib",
+#   "numpy",
+#   "polars",
+#   "ase",
+#   "rich",
+#   "chemparseplot[neb,plot]>=1.9.17,<2",
+#   "readcon>=0.13.1",
+#   "rgpycrumbs>=1.10.4",
+# ]
+# ///
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+import matplotlib.pyplot as plt
+
+try:
+    from rgpycrumbs._aux import warn_on_direct_script_import
+except ImportError:  # pragma: no cover
+    warn_on_direct_script_import = None
+
+if warn_on_direct_script_import is not None:
+    warn_on_direct_script_import(__name__, "rgpycrumbs eon plt-con")
+
+from chemparseplot.api import load_trajectory, plot_con_overlay, plot_con_overview
+from rich.logging import RichHandler
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s - %(message)s",
+    handlers=[RichHandler(rich_tracebacks=True, show_path=False, markup=True)],
+)
+log = logging.getLogger("rich")
+
+
+def _has_forces(traj) -> bool:
+    return (
+        traj.table is not None
+        and not traj.table.is_empty()
+        and "fmax" in traj.table.columns
+        and traj.table["fmax"].null_count() < traj.table.height
+    )
+
+
+@click.command()
+@click.argument(
+    "con_files",
+    nargs=-1,
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Output figure (default: <first_stem>_profile.pdf).",
+)
+@click.option(
+    "--label",
+    "labels",
+    type=str,
+    multiple=True,
+    help="Legend label per input (must match count when multi-file).",
+)
+@click.option(
+    "--energy-unit",
+    type=click.Choice(["eV", "kcal/mol", "kJ/mol"]),
+    default="eV",
+    show_default=True,
+)
+@click.option(
+    "--absolute/--relative",
+    default=False,
+    help="Absolute energies vs ΔE from each trajectory's first frame.",
+)
+@click.option(
+    "--no-forces",
+    is_flag=True,
+    default=False,
+    help="Skip force panel (single-traj mode only).",
+)
+@click.option(
+    "--structures",
+    type=click.Choice(["none", "endpoints", "linspace", "all"]),
+    default="none",
+    show_default=True,
+    help="Structure strip mode (single-traj; ase renderer by default).",
+)
+@click.option(
+    "--max-structs",
+    type=int,
+    default=8,
+    show_default=True,
+    help="Cap on strip structures for linspace/all.",
+)
+@click.option(
+    "--strip-renderer",
+    type=click.Choice(["ase", "xyzrender"]),
+    default="ase",
+    show_default=True,
+)
+@click.option("--dpi", type=int, default=200, show_default=True)
+@click.option("--title", type=str, default=None)
+def main(
+    con_files,
+    output,
+    labels,
+    energy_unit,
+    absolute,
+    no_forces,
+    structures,
+    max_structs,
+    strip_renderer,
+    dpi,
+    title,
+):
+    """Plot CON/chemfiles trajectory profile(s).
+
+    One file: energy (+ forces + optional structure strip).
+    Multiple files: energy overlay only.
+    """
+    paths = list(con_files)
+    trajs = [load_trajectory(p) for p in paths]
+    for p, traj in zip(paths, trajs, strict=False):
+        n_e = int(sum(1 for v in traj.energies if v == v))
+        log.info(
+            "Loaded %s: %d frames, energy finite=%d, forces=%s, source=%s",
+            p.name,
+            traj.n_frames,
+            n_e,
+            "yes" if _has_forces(traj) else "no",
+            traj.source,
+        )
+
+    if len(trajs) == 1:
+        fig = plot_con_overview(
+            trajs[0],
+            energy_unit=energy_unit,
+            relative=not absolute,
+            show_forces=not no_forces,
+            structures=structures,
+            max_structs=max_structs,
+            strip_renderer=strip_renderer,
+            title=title or paths[0].name,
+        )
+    else:
+        if labels and len(labels) != len(trajs):
+            raise click.UsageError(
+                f"--label count ({len(labels)}) must match files ({len(trajs)})"
+            )
+        fig, ax = plt.subplots(figsize=(5.37, 3.8), constrained_layout=True)
+        plot_con_overlay(
+            trajs,
+            labels=list(labels) if labels else None,
+            ax=ax,
+            energy_unit=energy_unit,
+            relative=not absolute,
+            title=title or "CON overlay",
+        )
+    out = output or paths[0].with_name(f"{paths[0].stem}_profile.pdf")
+    fig.savefig(out, dpi=dpi, bbox_inches="tight")
+    log.info("Wrote %s", out)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/rgpycrumbs/eon/plt_min.py
+++ b/rgpycrumbs/eon/plt_min.py
@@ -103,8 +103,11 @@ def plot_min_from_settings(settings: dict[str, Any]) -> Path | None:
     plot_type = settings["plot_type"]
     project_path = settings["project_path"]
     surface_type = settings["surface_type"]
-    auto_thin = bool(settings.get("auto_thin", False))
-    max_surface_points = int(settings.get("max_surface_points", 64))
+    from rgpycrumbs.eon.plot_config import surface_fit_config
+
+    fit_cfg = surface_fit_config(settings)
+    auto_thin = fit_cfg.auto_thin
+    max_surface_points = fit_cfg.max_surface_points
     ira_kmax = settings["ira_kmax"]
     energy_unit = settings["energy_unit"]
     energy_cap = settings.get("energy_cap")
@@ -382,7 +385,7 @@ def _plot_landscape(
         strip_renderer=strip_renderer,
         xyzrender_config=xyzrender_config,
         strip_spacing=max(strip_spacing, 2.2),
-        # TOML plot config keys (not CLI flags): auto_thin, max_surface_points
+        # TOML plot config keys via surface_fit_config / SurfaceFitConfig
         surface_fit={
             "auto_thin": auto_thin,
             "max_surface_points": max_surface_points,

--- a/rgpycrumbs/eon/plt_neb.py
+++ b/rgpycrumbs/eon/plt_neb.py
@@ -229,8 +229,11 @@ def plot_neb_from_settings(settings: dict[str, Any]) -> Path | None:
     show_pts = settings["show_pts"]
     plot_mode = settings["plot_mode"]
     surface_type = settings["surface_type"]
-    auto_thin = bool(settings.get("auto_thin", False))
-    max_surface_points = int(settings.get("max_surface_points", 64))
+    from rgpycrumbs.eon.plot_config import surface_fit_config
+
+    fit_cfg = surface_fit_config(settings)
+    auto_thin = fit_cfg.auto_thin
+    max_surface_points = fit_cfg.max_surface_points
     n_inducing = settings.get("n_inducing")
     output_file = settings.get("output_file")
     start = settings.get("start")
@@ -528,6 +531,7 @@ def plot_neb_from_settings(settings: dict[str, Any]) -> Path | None:
                 basis=global_basis,
                 auto_thin=auto_thin,
                 max_surface_points=max_surface_points,
+                surface_fit=fit_cfg,
             )
 
         # Path Overlay (Final Step)

--- a/tests/test_dry_review_batch.py
+++ b/tests/test_dry_review_batch.py
@@ -14,7 +14,14 @@ import numpy as np
 import pytest
 
 from rgpycrumbs.api import suite_pins
-from rgpycrumbs.basetypes import DimerOpt, MolGeom, SaddleMeasure, SpinID, nebiter, nebpath
+from rgpycrumbs.basetypes import (
+    DimerOpt,
+    MolGeom,
+    SaddleMeasure,
+    SpinID,
+    nebiter,
+    nebpath,
+)
 from rgpycrumbs.eon.plot_config import (
     click_nondefault_overrides,
     extract_config_layers,
@@ -32,7 +39,7 @@ def test_suite_pins():
 
 
 def test_suite_pins_soft_fail(monkeypatch):
-    import rgpycrumbs.api as api
+    from rgpycrumbs import api
 
     def boom(*_a, **_k):
         raise RuntimeError("cfg")
@@ -111,7 +118,7 @@ def test_chemgp_deprecation_warning():
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         try:
-            import rgpycrumbs.chemgp as _cg  # noqa: F401
+            import rgpycrumbs.chemgp as _cg
         except ImportError as exc:
             pytest.skip(f"chemgp deps missing: {exc}")
         deps = [x for x in caught if issubclass(x.category, DeprecationWarning)]

--- a/tests/test_dry_review_batch.py
+++ b/tests/test_dry_review_batch.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+"""Coverage for suite DRY batch: suite_pins, surface_fit_config, basetypes, chemgp."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rgpycrumbs.api import suite_pins
+from rgpycrumbs.basetypes import DimerOpt, MolGeom, SaddleMeasure, SpinID, nebiter, nebpath
+from rgpycrumbs.eon.plot_config import (
+    click_nondefault_overrides,
+    extract_config_layers,
+    load_plot_config,
+    merge_plot_settings,
+    resolve_from_click,
+    surface_fit_config,
+)
+
+pytestmark = pytest.mark.pure
+
+
+def test_suite_pins():
+    assert isinstance(suite_pins(), dict)
+
+
+def test_suite_pins_soft_fail(monkeypatch):
+    import rgpycrumbs.api as api
+
+    def boom(*_a, **_k):
+        raise RuntimeError("cfg")
+
+    monkeypatch.setattr(api, "load_config", boom)
+    pins = api.suite_pins()
+    assert isinstance(pins, dict)
+
+
+def test_surface_fit_config_with_defaults():
+    s = merge_plot_settings(
+        "min", config_data={"shared": {"auto_thin": True, "max_surface_points": 8}}
+    )
+    cfg = surface_fit_config(s)
+    assert cfg.auto_thin is True
+    assert cfg.max_surface_points == 8
+
+
+def test_surface_fit_config_fallback(monkeypatch):
+    import builtins
+
+    import rgpycrumbs.eon.plot_config as pc
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name.startswith("chemparseplot"):
+            raise ImportError("no cpp")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(
+        pc,
+        "SurfaceFitConfig",
+        None,
+        raising=False,
+    )
+    cfg = surface_fit_config({"auto_thin": False, "max_surface_points": 16})
+    assert cfg.max_surface_points == 16
+    assert cfg.auto_thin is False
+
+
+def test_basetypes_reexport():
+    p = nebpath(0.0, 0.0, 0.0)
+    assert nebiter(1, p).iteration == 1
+    assert DimerOpt().saddle == "dimer"
+    assert SpinID(1, "s").spin == "s"
+    g = MolGeom(np.zeros((1, 3)), 0.0, np.zeros((1, 3)))
+    assert g.energy == 0.0
+    assert SaddleMeasure().success is False
+
+
+def test_basetypes_fallback(monkeypatch):
+    sys.modules.pop("rgpycrumbs.basetypes", None)
+
+    import builtins
+
+    real = builtins.__import__
+
+    def fake(name, globs=None, locs=None, fromlist=(), level=0):
+        if name.startswith("chemparseplot"):
+            raise ImportError("hidden")
+        return real(name, globs, locs, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake)
+    import rgpycrumbs.basetypes as bt
+
+    p = bt.nebpath(1.0, 2.0, 3.0)
+    assert bt.nebiter(0, p).nebpath.arc_dist == 2.0
+    sys.modules.pop("rgpycrumbs.basetypes", None)
+    importlib.invalidate_caches()
+
+
+def test_chemgp_deprecation_warning():
+    sys.modules.pop("rgpycrumbs.chemgp", None)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            import rgpycrumbs.chemgp as _cg  # noqa: F401
+        except ImportError as exc:
+            pytest.skip(f"chemgp deps missing: {exc}")
+        deps = [x for x in caught if issubclass(x.category, DeprecationWarning)]
+        assert deps, "expected DeprecationWarning on chemgp import"
+
+
+def test_load_plot_config_and_layers(tmp_path):
+    p = tmp_path / "plot.toml"
+    p.write_text(
+        '[shared]\nauto_thin = true\nmax_surface_points = 10\nenergy_unit = "eV"\n'
+        '[min]\nprefix = "m"\n'
+        "extra_flat = 1\n"
+    )
+    data = load_plot_config(p)
+    shared, _cmd = extract_config_layers(data, "min")
+    assert shared["auto_thin"] is True
+    settings = merge_plot_settings("min", config_path=p, cli_overrides={"dpi": 150})
+    assert settings["dpi"] == 150
+    assert settings["auto_thin"] is True
+
+
+def test_merge_unknown_command():
+    with pytest.raises(ValueError, match="Unknown"):
+        merge_plot_settings("nope")
+
+
+def test_merge_passthrough_and_job_dir(tmp_path):
+    settings = merge_plot_settings(
+        "min",
+        config_data={},
+        passthrough={"custom": 1},
+        cli_overrides={"job_dir": str(tmp_path)},
+    )
+    assert settings["custom"] == 1
+    assert settings["job_dir"][0] == Path(tmp_path)
+
+
+def test_resolve_from_click_like():
+    class Ctx:
+        def get_parameter_source(self, name):
+            from click.core import ParameterSource
+
+            if name == "dpi":
+                return ParameterSource.COMMANDLINE
+            return ParameterSource.DEFAULT
+
+    settings = resolve_from_click("neb", Ctx(), config=None, dpi=300, title="t")
+    assert settings["dpi"] == 300
+
+
+def test_plot_config_coercions(tmp_path):
+    from rgpycrumbs.eon.plot_config import _coerce_value
+
+    assert _coerce_value("figsize", [1, 2]) == (1.0, 2.0)
+    assert _coerce_value("label", "a") == ("a",)
+    assert _coerce_value("label", ["a", "b"]) == ("a", "b")
+    assert _coerce_value("job_dir", str(tmp_path)) == [Path(tmp_path)]
+    assert _coerce_value("job_dir", [str(tmp_path)])[0] == Path(tmp_path)
+    assert _coerce_value("con_file", "x.con") == Path("x.con")
+
+
+def test_merge_label_and_list_job_dir(tmp_path):
+    s = merge_plot_settings(
+        "min",
+        config_data={"min": {"label": ["a"], "job_dir": [str(tmp_path)]}},
+    )
+    assert s["label"] == ("a",)
+    assert isinstance(s["job_dir"], tuple)
+
+
+def test_click_nondefault():
+    from click.core import ParameterSource
+
+    class Ctx:
+        def get_parameter_source(self, name):
+            if name == "dpi":
+                return ParameterSource.COMMANDLINE
+            if name == "config":
+                return ParameterSource.COMMANDLINE
+            return ParameterSource.DEFAULT
+
+    ov = click_nondefault_overrides(Ctx(), {"dpi": 99, "config": "x", "title": "t"})
+    assert "dpi" in ov
+    assert "config" not in ov
+
+
+def test_load_plot_config_non_table(monkeypatch, tmp_path):
+    import rgpycrumbs.eon.plot_config as pc
+
+    p = tmp_path / "x.toml"
+    p.write_text("1")
+    monkeypatch.setattr(pc.tomllib, "loads", lambda _b: 123)
+    with pytest.raises(ValueError, match="table"):
+        pc.load_plot_config(p)
+
+
+def test_coerce_none_and_job_dir_list_of_paths():
+    from rgpycrumbs.eon.plot_config import _coerce_value
+
+    assert _coerce_value("dpi", None) is None
+    assert _coerce_value("job_dir", [Path("a"), Path("b")])[0] == Path("a")
+    assert _coerce_value("label", ("x",)) == ("x",)
+
+
+def test_extract_nested_dict_skipped():
+    shared, cmd = extract_config_layers(
+        {"shared": {"dpi": 100}, "min": {"prefix": "p"}, "nested": {"a": 1}, "flat": 2},
+        "min",
+    )
+    assert "nested" not in shared
+    assert cmd.get("flat") == 2
+
+
+def test_merge_cli_none_skip_and_job_dir_str_label_str(tmp_path):
+    s = merge_plot_settings(
+        "min",
+        config_data={},
+        cli_overrides={
+            "weird": None,
+            "job_dir": str(tmp_path),
+            "label": "lab",
+            "dpi": None,
+        },
+    )
+    assert "weird" not in s or s.get("weird") is None
+    assert s["job_dir"][0] == Path(tmp_path)
+    assert s["label"] == ("lab",)
+
+
+def test_merge_job_dir_tuple_and_label_list(tmp_path):
+    s = merge_plot_settings(
+        "min",
+        config_data={
+            "min": {
+                "job_dir": (str(tmp_path),),
+                "label": ["x", "y"],
+            }
+        },
+    )
+    assert isinstance(s["job_dir"], tuple)
+    assert s["label"] == ("x", "y")
+
+
+def test_merge_job_dir_path_and_list_normalize(tmp_path):
+    s = merge_plot_settings(
+        "min",
+        config_data={},
+        cli_overrides={"job_dir": tmp_path},
+    )
+    assert s["job_dir"] == (tmp_path,)
+
+    s2 = merge_plot_settings(
+        "min",
+        config_data={},
+        passthrough={"job_dir": [tmp_path / "a", tmp_path / "b"]},
+    )
+    assert len(s2["job_dir"]) == 2
+
+
+def test_coerce_unknown_key_passthrough():
+    from rgpycrumbs.eon.plot_config import _coerce_value
+
+    assert _coerce_value("other", 1) == 1
+
+
+def test_extract_shared_key_at_top_level():
+    shared, cmd = extract_config_layers({"auto_thin": True, "prefix": "z"}, "min")
+    assert shared["auto_thin"] is True
+    assert cmd["prefix"] == "z"
+
+
+def test_merge_label_already_str_from_settings(tmp_path):
+    s = merge_plot_settings(
+        "min",
+        config_data={"min": {"label": "solo", "job_dir": [str(tmp_path)]}},
+        cli_overrides={"label": ["a", "b"]},
+    )
+    assert s["label"] == ("a", "b")
+
+
+def test_merge_job_dir_list_and_label_list_via_settings():
+    s = merge_plot_settings(
+        "min",
+        config_data={},
+        cli_overrides={"job_dir": ["a", "b"], "label": ["L1"]},
+    )
+    assert s["job_dir"] == (Path("a"), Path("b"))
+    assert s["label"] == ("L1",)
+
+
+def test_merge_job_dir_tuple_normalize():
+    s = merge_plot_settings(
+        "min",
+        config_data={},
+        cli_overrides={"job_dir": (Path("x"), Path("y"))},
+    )
+    assert s["job_dir"] == (Path("x"), Path("y"))
+
+
+def test_merge_passthrough_raw_job_dir_and_label_shapes(tmp_path):
+    s = merge_plot_settings(
+        "min",
+        config_data={},
+        passthrough={
+            "job_dir": str(tmp_path),
+            "label": "solo",
+        },
+    )
+    assert s["job_dir"] == (Path(tmp_path),)
+    assert s["label"] == ("solo",)
+
+    s2 = merge_plot_settings(
+        "min",
+        config_data={},
+        passthrough={
+            "job_dir": [str(tmp_path / "a")],
+            "label": ["a", "b"],
+        },
+    )
+    assert s2["job_dir"] == (Path(tmp_path / "a"),)
+    assert s2["label"] == ("a", "b")
+
+    s3 = merge_plot_settings(
+        "min",
+        config_data={},
+        passthrough={
+            "job_dir": (tmp_path / "t",),
+        },
+    )
+    assert s3["job_dir"] == (tmp_path / "t",)
+
+
+def test_merge_label_non_sequence_left_alone():
+    s = merge_plot_settings(
+        "min",
+        config_data={},
+        passthrough={"label": 42},
+    )
+    assert s["label"] == 42

--- a/tests/test_ensure_import.py
+++ b/tests/test_ensure_import.py
@@ -174,6 +174,7 @@ class TestEnsureImport:
     def test_uv_install_triggered(self, monkeypatch, tmp_path):
         """With RGPYCRUMBS_AUTO_DEPS=1, triggers uv install."""
         monkeypatch.setenv("RGPYCRUMBS_AUTO_DEPS", "1")
+        monkeypatch.delenv("RGPKGS_AUTO_DEPS", raising=False)
         monkeypatch.delenv("RGPYCRUMBS_PARENT_SITE_PACKAGES", raising=False)
 
         cache_dir = tmp_path / "rgpycrumbs" / "deps"
@@ -219,6 +220,7 @@ class TestEnsureImport:
     def test_no_auto_deps_raises(self, mock_import, monkeypatch):
         """Without RGPYCRUMBS_AUTO_DEPS, raises ImportError with message."""
         monkeypatch.delenv("RGPYCRUMBS_AUTO_DEPS", raising=False)
+        monkeypatch.delenv("RGPKGS_AUTO_DEPS", raising=False)
         monkeypatch.delenv("RGPYCRUMBS_PARENT_SITE_PACKAGES", raising=False)
         monkeypatch.setattr(sys, "path", ["/local/lib"])
         mock_import.side_effect = ImportError("nope")
@@ -226,10 +228,46 @@ class TestEnsureImport:
         with pytest.raises(ImportError, match="pip install"):
             ensure_import("jax")
 
+    def test_rgpkgs_auto_deps_triggers_uv_install(self, monkeypatch, tmp_path):
+        """Ecosystem RGPKGS_AUTO_DEPS=1 alone enables auto-install (no legacy env)."""
+        monkeypatch.delenv("RGPYCRUMBS_AUTO_DEPS", raising=False)
+        monkeypatch.delenv("RGPYCRUMBS_PARENT_SITE_PACKAGES", raising=False)
+        monkeypatch.setenv("RGPKGS_AUTO_DEPS", "1")
+
+        cache_dir = tmp_path / "rgpycrumbs" / "deps"
+        monkeypatch.setattr("rgpycrumbs._aux._get_dep_cache_dir", lambda: cache_dir)
+
+        original_import = importlib.import_module
+        uv_called_with = []
+        fake_mod = types.ModuleType("scipy")
+        installed = False
+
+        def mock_import(name):
+            if name == "scipy" and not installed:
+                raise ImportError("not installed")
+            if name == "scipy" and installed:
+                return fake_mod
+            return original_import(name)
+
+        def uv_install_and_toggle(spec, target):
+            nonlocal installed
+            uv_called_with.append((spec, target))
+            target.mkdir(parents=True, exist_ok=True)
+            installed = True
+
+        monkeypatch.setattr("rgpycrumbs._aux._uv_install", uv_install_and_toggle)
+        monkeypatch.setattr(importlib, "import_module", mock_import)
+
+        result = ensure_import("scipy")
+        assert result is fake_mod
+        assert len(uv_called_with) == 1
+        assert "scipy" in uv_called_with[0][0]
+
     @patch("importlib.import_module")
     def test_unknown_module_message(self, mock_import, monkeypatch):
         """Unknown modules get a conda/pixi suggestion."""
         monkeypatch.delenv("RGPYCRUMBS_AUTO_DEPS", raising=False)
+        monkeypatch.delenv("RGPKGS_AUTO_DEPS", raising=False)
         monkeypatch.delenv("RGPYCRUMBS_PARENT_SITE_PACKAGES", raising=False)
         monkeypatch.setattr(sys, "path", ["/local/lib"])
         mock_import.side_effect = ImportError("nope")
@@ -280,6 +318,7 @@ class TestLazyModule:
 class TestWarnOnDirectScriptImport:
     def test_warns_when_imported_without_dispatch_env(self, monkeypatch):
         monkeypatch.delenv("RGPYCRUMBS_AUTO_DEPS", raising=False)
+        monkeypatch.delenv("RGPKGS_AUTO_DEPS", raising=False)
         monkeypatch.delenv("RGPYCRUMBS_PARENT_SITE_PACKAGES", raising=False)
         monkeypatch.delenv("RGPYCRUMBS_SUPPRESS_SCRIPT_IMPORT_WARNING", raising=False)
 
@@ -290,6 +329,7 @@ class TestWarnOnDirectScriptImport:
 
     def test_no_warning_for_main_execution(self, monkeypatch):
         monkeypatch.delenv("RGPYCRUMBS_AUTO_DEPS", raising=False)
+        monkeypatch.delenv("RGPKGS_AUTO_DEPS", raising=False)
         monkeypatch.delenv("RGPYCRUMBS_PARENT_SITE_PACKAGES", raising=False)
         monkeypatch.delenv("RGPYCRUMBS_SUPPRESS_SCRIPT_IMPORT_WARNING", raising=False)
 
@@ -300,6 +340,20 @@ class TestWarnOnDirectScriptImport:
 
     def test_no_warning_when_auto_deps_enabled(self, monkeypatch):
         monkeypatch.setenv("RGPYCRUMBS_AUTO_DEPS", "1")
+        monkeypatch.delenv("RGPKGS_AUTO_DEPS", raising=False)
+        monkeypatch.delenv("RGPYCRUMBS_PARENT_SITE_PACKAGES", raising=False)
+        monkeypatch.delenv("RGPYCRUMBS_SUPPRESS_SCRIPT_IMPORT_WARNING", raising=False)
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            warn_on_direct_script_import(
+                "rgpycrumbs.eon.plt_neb", "rgpycrumbs eon plt-neb"
+            )
+        assert not record
+
+    def test_no_warning_when_rgpkgs_auto_deps_enabled(self, monkeypatch):
+        monkeypatch.delenv("RGPYCRUMBS_AUTO_DEPS", raising=False)
+        monkeypatch.setenv("RGPKGS_AUTO_DEPS", "1")
         monkeypatch.delenv("RGPYCRUMBS_PARENT_SITE_PACKAGES", raising=False)
         monkeypatch.delenv("RGPYCRUMBS_SUPPRESS_SCRIPT_IMPORT_WARNING", raising=False)
 

--- a/tests/test_plt_con.py
+++ b/tests/test_plt_con.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+"""Cover plt-con without importing matplotlib at collection time."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.pure
+
+
+class _FakeTable:
+    def __init__(self, columns, height, null_count=0, empty=False):
+        self.columns = columns
+        self.height = height
+        self._null_count = null_count
+        self._empty = empty
+
+    def is_empty(self):
+        return self._empty
+
+    def __getitem__(self, key):
+        return types.SimpleNamespace(null_count=lambda: self._null_count)
+
+
+class _FakeTraj:
+    def __init__(self, *, energies, n_frames, source, table):
+        self.energies = energies
+        self.n_frames = n_frames
+        self.source = source
+        self.table = table
+
+
+def _install_plot_stubs(monkeypatch):
+    fig = MagicMock(name="fig")
+    ax = MagicMock(name="ax")
+
+    mpl = types.ModuleType("matplotlib")
+    plt = types.ModuleType("matplotlib.pyplot")
+    plt.subplots = MagicMock(return_value=(fig, ax))
+    plt.close = MagicMock()
+    monkeypatch.setitem(sys.modules, "matplotlib", mpl)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", plt)
+
+    cpp = types.ModuleType("chemparseplot")
+    cpp_api = types.ModuleType("chemparseplot.api")
+    cpp_api.load_trajectory = MagicMock()
+    cpp_api.plot_con_overview = MagicMock(return_value=fig)
+    cpp_api.plot_con_overlay = MagicMock()
+    cpp.api = cpp_api
+    monkeypatch.setitem(sys.modules, "chemparseplot", cpp)
+    monkeypatch.setitem(sys.modules, "chemparseplot.api", cpp_api)
+
+    rich = types.ModuleType("rich")
+    rich_logging = types.ModuleType("rich.logging")
+
+    class _Handler:
+        def __init__(self, *a, **k):
+            pass
+
+    rich_logging.RichHandler = _Handler
+    rich.logging = rich_logging
+    monkeypatch.setitem(sys.modules, "rich", rich)
+    monkeypatch.setitem(sys.modules, "rich.logging", rich_logging)
+
+    return fig, ax, cpp_api, plt
+
+
+def _load_plt_con(monkeypatch):
+    _install_plot_stubs(monkeypatch)
+    sys.modules.pop("rgpycrumbs.eon.plt_con", None)
+    return importlib.import_module("rgpycrumbs.eon.plt_con")
+
+
+def test_has_forces_true_and_false(monkeypatch):
+    plt_con = _load_plt_con(monkeypatch)
+    good = _FakeTraj(
+        energies=[0.0],
+        n_frames=1,
+        source="con",
+        table=_FakeTable(["fmax"], height=2, null_count=0),
+    )
+    assert plt_con._has_forces(good) is True
+    missing = _FakeTraj(
+        energies=[0.0],
+        n_frames=1,
+        source="con",
+        table=_FakeTable(["energy"], height=2),
+    )
+    assert plt_con._has_forces(missing) is False
+    empty = _FakeTraj(
+        energies=[0.0],
+        n_frames=1,
+        source="con",
+        table=_FakeTable(["fmax"], height=0, empty=True),
+    )
+    assert plt_con._has_forces(empty) is False
+    none_table = _FakeTraj(energies=[0.0], n_frames=1, source="con", table=None)
+    assert plt_con._has_forces(none_table) is False
+    all_null = _FakeTraj(
+        energies=[0.0],
+        n_frames=1,
+        source="con",
+        table=_FakeTable(["fmax"], height=2, null_count=2),
+    )
+    assert plt_con._has_forces(all_null) is False
+
+
+def test_single_traj_overview(monkeypatch, tmp_path):
+    fig, _ax, cpp_api, plt = _install_plot_stubs(monkeypatch)
+    sys.modules.pop("rgpycrumbs.eon.plt_con", None)
+    plt_con = importlib.import_module("rgpycrumbs.eon.plt_con")
+
+    con = tmp_path / "movie.con"
+    con.write_text("x\n")
+    traj = _FakeTraj(
+        energies=[1.0, float("nan")],
+        n_frames=2,
+        source="con",
+        table=_FakeTable(["fmax"], height=2, null_count=0),
+    )
+    cpp_api.load_trajectory.return_value = traj
+
+    from click.testing import CliRunner
+
+    result = CliRunner().invoke(plt_con.main, [str(con)])
+    assert result.exit_code == 0, result.output
+    cpp_api.plot_con_overview.assert_called_once()
+    kwargs = cpp_api.plot_con_overview.call_args.kwargs
+    assert kwargs["relative"] is True
+    assert kwargs["show_forces"] is True
+    fig.savefig.assert_called_once()
+    plt.close.assert_called_once_with(fig)
+    out = tmp_path / "movie_profile.pdf"
+    assert out == Path(fig.savefig.call_args.args[0])
+
+
+def test_multi_file_overlay_and_label_mismatch(monkeypatch, tmp_path):
+    _fig, _ax, cpp_api, plt = _install_plot_stubs(monkeypatch)
+    sys.modules.pop("rgpycrumbs.eon.plt_con", None)
+    plt_con = importlib.import_module("rgpycrumbs.eon.plt_con")
+
+    a = tmp_path / "a.con"
+    b = tmp_path / "b.con"
+    a.write_text("a\n")
+    b.write_text("b\n")
+    traj = _FakeTraj(
+        energies=[0.0],
+        n_frames=1,
+        source="con",
+        table=_FakeTable(["energy"], height=1),
+    )
+    cpp_api.load_trajectory.return_value = traj
+
+    from click.testing import CliRunner
+
+    runner = CliRunner()
+    bad = runner.invoke(plt_con.main, [str(a), str(b), "--label", "only-one"])
+    assert bad.exit_code != 0
+    assert "must match" in (bad.output + str(bad.exception))
+
+    ok = runner.invoke(
+        plt_con.main,
+        [str(a), str(b), "--label", "A", "--label", "B", "--absolute", "-o", str(tmp_path / "ov.pdf")],
+    )
+    assert ok.exit_code == 0, ok.output
+    cpp_api.plot_con_overlay.assert_called_once()
+    kwargs = cpp_api.plot_con_overlay.call_args.kwargs
+    assert kwargs["labels"] == ["A", "B"]
+    assert kwargs["relative"] is False
+    plt.subplots.assert_called_once()

--- a/tests/test_plt_con.py
+++ b/tests/test_plt_con.py
@@ -168,7 +168,17 @@ def test_multi_file_overlay_and_label_mismatch(monkeypatch, tmp_path):
 
     ok = runner.invoke(
         plt_con.main,
-        [str(a), str(b), "--label", "A", "--label", "B", "--absolute", "-o", str(tmp_path / "ov.pdf")],
+        [
+            str(a),
+            str(b),
+            "--label",
+            "A",
+            "--label",
+            "B",
+            "--absolute",
+            "-o",
+            str(tmp_path / "ov.pdf"),
+        ],
     )
     assert ok.exit_code == 0, ok.output
     cpp_api.plot_con_overlay.assert_called_once()

--- a/tests/test_plt_con.py
+++ b/tests/test_plt_con.py
@@ -176,3 +176,15 @@ def test_multi_file_overlay_and_label_mismatch(monkeypatch, tmp_path):
     assert kwargs["labels"] == ["A", "B"]
     assert kwargs["relative"] is False
     plt.subplots.assert_called_once()
+
+
+def test_plt_con_script_declares_python_floor():
+    script = Path(__file__).resolve().parent.parent / "rgpycrumbs" / "eon" / "plt_con.py"
+    text = script.read_text()
+    assert '# requires-python = ">=3.11"' in text
+
+
+def test_plt_con_is_discovered_as_eon_script():
+    from rgpycrumbs.cli import _get_scripts_in_folder
+
+    assert "plt_con" in _get_scripts_in_folder("eon")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -16,6 +16,7 @@ from rgpycrumbs.api import (
     normalize_pypi_name,
     pins_to_constraint_lines,
     resolve_lock_path_layered,
+    suite_pins,
     user_config_path,
 )
 
@@ -68,3 +69,19 @@ class TestPublicEnsureImport:
         np = ensure_import("numpy")
         assert hasattr(np, "array")
         assert np.array([1, 2]).sum() == 3
+
+
+class TestSuitePins:
+    def test_suite_pins_returns_dict(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("RGPKGS_LOCK_PINS", raising=False)
+        pins = suite_pins()
+        assert isinstance(pins, dict)
+
+    def test_suite_pins_merges_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RGPKGS_LOCK_PINS", '{"numpy": "2.0.0"}')
+        pins = suite_pins()
+        assert pins.get(normalize_pypi_name("numpy")) == "2.0.0"


### PR DESCRIPTION
## Summary

Follow-up from the multi-package rgpkgs design review.

- `ensure_import` honors `RGPKGS_AUTO_DEPS` (legacy `RGPYCRUMBS_AUTO_DEPS` still works). AUTO_DEPS stays opt-in; CLI isolation is still PEP 723 + uv.
- `rgpycrumbs.api.suite_pins()` is the single pin merge; consumers should call this.
- `basetypes` re-exports `chemparseplot.basetypes` when available.
- `plot_config.surface_fit_config()` maps TOML knobs to chemparseplot `SurfaceFitConfig`; plt-min/plt-neb use it.
- `rgpycrumbs.chemgp` library re-exports warn toward chemparseplot (CLI stays).

## Test plan

- [x] `pytest tests/test_ensure_import.py tests/test_public_api.py tests/test_basetypes.py`
- [x] `surface_fit_config` smoke on merged min settings