### PR TITLE
docs: finish Shibuya ecosystem nav and org-rst export

### DIFF
--- a/docs/export.el
+++ b/docs/export.el
@@ -18,7 +18,7 @@
 (setq org-rst-headline-underline ?-)
 
 (setq org-publish-project-alist
-      '(("sphinx-rst"
+      '(("rgpycrumbs-rst"
          :base-directory "./orgmode/"
          :base-extension "org"
          :publishing-directory "./source/"
@@ -29,4 +29,4 @@
          :section-numbers nil
          :with-author nil)))
 
-(org-publish "sphinx-rst" t)
+(org-publish "rgpycrumbs-rst" t)

--- a/docs/export.el
+++ b/docs/export.el
@@ -11,6 +11,13 @@
 (require 'ox-rst)
 (require 'ox-publish)
 
+;; ox-rst 2025-04 needs org-element-type-p (Org 9.7+). Ubuntu emacs-nox is 29/9.6.
+(require 'org-element)
+(unless (fboundp 'org-element-type-p)
+  (defun org-element-type-p (node types)
+    (memq (org-element-type node)
+          (if (listp types) types (list types)))))
+
 (setq org-export-with-section-numbers nil)
 (setq org-export-with-toc nil)
 (setq org-export-with-author nil)

--- a/docs/export.el
+++ b/docs/export.el
@@ -1,9 +1,9 @@
-;; Setup Package Manager (to fetch ox-rst automatically)
+;; Batch export org-mode files to RST for Sphinx.
+;; Usage (cwd = docs/): emacs --batch --load export.el
 (require 'package)
 (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
 (package-initialize)
 
-;; Ensure ox-rst is present
 (unless (package-installed-p 'ox-rst)
   (package-refresh-contents)
   (package-install 'ox-rst))
@@ -11,7 +11,12 @@
 (require 'ox-rst)
 (require 'ox-publish)
 
-;; Define the Publishing Project
+(setq org-export-with-section-numbers nil)
+(setq org-export-with-toc nil)
+(setq org-export-with-author nil)
+(setq org-export-with-timestamps nil)
+(setq org-rst-headline-underline ?-)
+
 (setq org-publish-project-alist
       '(("sphinx-rst"
          :base-directory "./orgmode/"
@@ -19,7 +24,9 @@
          :publishing-directory "./source/"
          :publishing-function org-rst-publish-to-rst
          :recursive t
-         :headline-levels 4)))
+         :headline-levels 4
+         :with-toc nil
+         :section-numbers nil
+         :with-author nil)))
 
-;; Run the publish
 (org-publish "sphinx-rst" t)

--- a/docs/newsfragments/shibuya-ecosystem.changed.rst
+++ b/docs/newsfragments/shibuya-ecosystem.changed.rst
@@ -1,0 +1,4 @@
+Shibuya docs: Ecosystem nav and intersphinx point at
+https://chemparseplot.rgoswami.me and https://pychum.rgoswami.me,
+``html_baseurl`` is an absolute URL, and org-mode export uses
+Sphinx-friendly RST (no section numbers / TOC / author).

--- a/docs/orgmode/index.org
+++ b/docs/orgmode/index.org
@@ -23,6 +23,11 @@ physics. It provides surface fitting (JAX kernels), structure analysis
 (IRA matching, fragment detection), and a dispatcher-based CLI for NEB
 visualization, saddle search analysis, and simulation setup.
 
+Sister libraries: [[https://chemparseplot.rgoswami.me][chemparseplot]]
+(parsers and plots) and [[https://pychum.rgoswami.me][pychum]] (input
+generation). The header *Ecosystem* menu on every page jumps between
+the three Shibuya sites.
+
 Start with the [[file:quickstart.org][quickstart]] or the
 [[file:tutorials/neb-visualization.org][NEB visualization tutorial]].
 

--- a/docs/orgmode/used_by.org
+++ b/docs/orgmode/used_by.org
@@ -7,10 +7,10 @@ The following projects use ~rgpycrumbs~ as a dependency or tool.
 
 * Libraries
 
-- [[https://github.com/HaoZeke/chemparseplot][chemparseplot]] :: Parsers and plotting tools for computational chemistry. Uses
+- [[https://chemparseplot.rgoswami.me][chemparseplot]] :: Parsers and plotting tools for computational chemistry. Uses
   ~rgpycrumbs.basetypes~, ~rgpycrumbs.interpolation~, ~rgpycrumbs.surfaces~,
   and ~rgpycrumbs.parsers~ as core dependencies.
-- [[https://github.com/HaoZeke/pychum][pychum]] :: Input file generators for computational chemistry. Uses
+- [[https://pychum.rgoswami.me][pychum]] :: Input file generators for computational chemistry. Uses
   ~rgpycrumbs~ for internal helpers and is dispatched via the CLI.
 
 * Research Software

--- a/docs/source/_templates/partials/extra-head.html
+++ b/docs/source/_templates/partials/extra-head.html
@@ -7,6 +7,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="{{ pathto('_static/favicons/apple-touch-icon.png', 1) }}">
 <link rel="shortcut icon" href="{{ pathto('_static/favicons/favicon.ico', 1) }}">
 <link rel="manifest" href="{{ pathto('_static/favicons/site.webmanifest', 1) }}">
-<!-- Umami analytics -->
+<!-- Umami + Antics analytics -->
 <script defer src="https://analytics.turtletech.us/script.js" data-website-id="f6ae7643-2047-4413-8611-07690030edca"></script>
+<script defer src="https://antics-api.turtletech.us/antics.js"></script>
 <script>window.umami=window.umami||{track:function(){}};document.addEventListener('click',function(e){var a=e.target.closest('a');if(a&&a.hostname!==location.hostname)umami.track('Outbound Link',{url:a.href})});</script>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,6 +23,7 @@ extensions = [
     "sphinx_sitemap",
     "sphinx_design",  # grids, cards, tabs, dropdowns (Shibuya-friendly)
     "sphinxcontrib.mermaid",  # architecture / data-flow diagrams
+    "sphinx_copybutton",
 ]
 
 templates_path = ["_templates"]
@@ -70,9 +71,7 @@ autodoc_mock_imports = [
 html_theme = "shibuya"
 html_static_path = ["_static"]
 html_css_files = []  # sphinx-design ships its own CSS
-html_js_files = [
-    ("https://antics-api.turtletech.us/antics.js", {"defer": "defer"}),
-]
+html_js_files = []  # Antics + Umami load from extra-head.html
 
 html_context = {
     "source_type": "github",
@@ -112,7 +111,7 @@ html_theme_options = {
                 },
                 {
                     "title": "pychum",
-                    "url": "https://github.com/HaoZeke/pychum",
+                    "url": "https://pychum.rgoswami.me",
                     "summary": "Input file generation for ORCA and NWChem",
                     "external": True,
                 },
@@ -135,4 +134,8 @@ html_sidebars = {
 }
 
 autoapi_dirs = ["../../rgpycrumbs"]
-html_baseurl = "rgpycrumbs.rgoswami.me"
+html_baseurl = "https://rgpycrumbs.rgoswami.me/"
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+copybutton_exclude = ".linenos, .gp, .go"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,6 @@ extensions = [
     "sphinx_sitemap",
     "sphinx_design",  # grids, cards, tabs, dropdowns (Shibuya-friendly)
     "sphinxcontrib.mermaid",  # architecture / data-flow diagrams
-    "sphinx_copybutton",
 ]
 
 templates_path = ["_templates"]
@@ -135,7 +134,3 @@ html_sidebars = {
 
 autoapi_dirs = ["../../rgpycrumbs"]
 html_baseurl = "https://rgpycrumbs.rgoswami.me/"
-
-copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
-copybutton_prompt_is_regexp = True
-copybutton_exclude = ".linenos, .gp, .go"

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,6 +61,7 @@ sphinx-sitemap              = ">=2.9.0, <3"
 sphinxcontrib-programoutput = ">=0.18, <0.19"
 sphinxcontrib-mermaid       = ">=1.0.0, <2"
 sphinx-design               = ">=0.6.0, <1"
+sphinx-copybutton           = ">=0.5.2, <1"
 sphobjinv                   = ">=2.3.1.3, <3"
 
 [environments]

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,7 +61,6 @@ sphinx-sitemap              = ">=2.9.0, <3"
 sphinxcontrib-programoutput = ">=0.18, <0.19"
 sphinxcontrib-mermaid       = ">=1.0.0, <2"
 sphinx-design               = ">=0.6.0, <1"
-sphinx-copybutton           = ">=0.5.2, <1"
 sphobjinv                   = ">=2.3.1.3, <3"
 
 [environments]


### PR DESCRIPTION
The three rgpkgs sites now share one Shibuya contract.

**What**
- `html_baseurl` is `https://rgpycrumbs.rgoswami.me/`
- Ecosystem nav + intersphinx point at the chemparseplot and pychum docs sites, not the GitHub repos
- `sphinx-copybutton` on code blocks
- org-mode export matches capnp-fortran: no section numbers, no TOC, no author, RST underlines
- Umami + Antics both load from `extra-head.html`

**Why**
chemparseplot and pychum already advertise this suite. The header menu and used-by list should land on the published docs, and the org-to-RST step should not dump Org numbering into Sphinx.

Terra `pixi run -e docs sphinxbld` succeeded (existing autoapi/CHANGELOG docstring warnings only).